### PR TITLE
V2.10 Adds support for continuous mode in accelerometer

### DIFF
--- a/Core/Components/Inc/accelerometer.h
+++ b/Core/Components/Inc/accelerometer.h
@@ -49,7 +49,7 @@ typedef struct Accelerometer {
   uSWIFT_return_code_t (*parse_waves)(sbd_message_type_55 *accel_msg,
                                       float *priority);
   uSWIFT_return_code_t (*next_spectra)(sbd_message_type_55 *accel_msg,
-                                       float *priority);
+                                       float *priority, float threshold);
   uSWIFT_return_code_t (*uart_init)(void);
   uSWIFT_return_code_t (*uart_deinit)(void);
   uSWIFT_return_code_t (*uart_reset)(void);

--- a/Core/Components/Inc/accelerometer.h
+++ b/Core/Components/Inc/accelerometer.h
@@ -10,6 +10,7 @@
 #include "microSWIFT_return_codes.h"
 #include "sbd.h"
 #include "tx_api.h"
+#include <stdint.h>
 
 #define ACCEL_MAX_UART_TX_TICKS (TX_TIMER_TICKS_PER_SECOND)
 

--- a/Core/Components/Inc/accelerometer.h
+++ b/Core/Components/Inc/accelerometer.h
@@ -47,6 +47,8 @@ typedef struct Accelerometer {
   uSWIFT_return_code_t (*start_continuous)(void);
   uSWIFT_return_code_t (*parse_waves)(sbd_message_type_55 *accel_msg,
                                       float *priority);
+  uSWIFT_return_code_t (*next_spectra)(sbd_message_type_55 *accel_msg,
+                                       float *priority);
   uSWIFT_return_code_t (*uart_init)(void);
   uSWIFT_return_code_t (*uart_deinit)(void);
   uSWIFT_return_code_t (*uart_reset)(void);

--- a/Core/Components/Inc/accelerometer.h
+++ b/Core/Components/Inc/accelerometer.h
@@ -43,7 +43,8 @@ typedef struct Accelerometer {
 
   uSWIFT_return_code_t (*self_test)(accel_self_test_result_t *result);
   uSWIFT_return_code_t (*set_time)(uint32_t timestamp);
-  uSWIFT_return_code_t (*start_sampling)(void);
+  uSWIFT_return_code_t (*run_once)(void);
+  uSWIFT_return_code_t (*start_continuous)(void);
   uSWIFT_return_code_t (*parse_waves)(sbd_message_type_55 *accel_msg,
                                       float *priority);
   uSWIFT_return_code_t (*uart_init)(void);

--- a/Core/Components/Inc/accelerometer.h
+++ b/Core/Components/Inc/accelerometer.h
@@ -44,7 +44,8 @@ typedef struct Accelerometer {
   uSWIFT_return_code_t (*self_test)(accel_self_test_result_t *result);
   uSWIFT_return_code_t (*set_time)(uint32_t timestamp);
   uSWIFT_return_code_t (*start_sampling)(void);
-  uSWIFT_return_code_t (*parse_waves)(sbd_message_type_55 *accel_msg);
+  uSWIFT_return_code_t (*parse_waves)(sbd_message_type_55 *accel_msg,
+                                      float *priority);
   uSWIFT_return_code_t (*uart_init)(void);
   uSWIFT_return_code_t (*uart_deinit)(void);
   uSWIFT_return_code_t (*uart_reset)(void);

--- a/Core/Components/Src/accelerometer.c
+++ b/Core/Components/Src/accelerometer.c
@@ -17,6 +17,8 @@ uSWIFT_return_code_t _accel_run_once(void);
 uSWIFT_return_code_t _accel_start_continuous(void);
 uSWIFT_return_code_t _accel_parse_waves(sbd_message_type_55 *accel_msg,
                                         float *priority);
+uSWIFT_return_code_t _accel_next_spectra(sbd_message_type_55 *accel_msg,
+                                         float *priority);
 uSWIFT_return_code_t _accel_uart_init(void);
 uSWIFT_return_code_t _accel_uart_deinit(void);
 uSWIFT_return_code_t _accel_uart_reset(void);
@@ -32,6 +34,7 @@ void accelerometer_init(Accelerometer *accel, UART_HandleTypeDef *uart_handle,
   accel_self->run_once = _accel_run_once;
   accel_self->start_continuous = _accel_start_continuous;
   accel_self->parse_waves = _accel_parse_waves;
+  accel_self->next_spectra = _accel_next_spectra;
 
   accel_self->uart_init = _accel_uart_init;
   accel_self->uart_deinit = _accel_uart_deinit;
@@ -121,6 +124,44 @@ uSWIFT_return_code_t _accel_parse_waves(sbd_message_type_55 *accel_msg,
   return uSWIFT_SUCCESS;
 }
 
+uSWIFT_return_code_t _accel_next_spectra(sbd_message_type_55 *accel_msg,
+                                         float *priority) {
+  const char *next_spectra_command = "NS";
+
+  UINT ret;
+  ret = accel_self->uart_driver.write(
+      &accel_self->uart_driver, (uint8_t *)&(next_spectra_command[0]),
+      strlen(next_spectra_command), ACCEL_MAX_UART_TX_TICKS);
+  if (UART_OK != ret) {
+    return uSWIFT_IO_ERROR;
+  }
+
+  static int response_length = 6 + 340;
+  char waves_response[response_length];
+  memset(waves_response, 0, response_length);
+  // Blocking read for up to 1 minute so other background processing can finish.
+  // This only grabs spectra that are already ready.
+  // TODO(LEL): Should this query happen AFTER GNSS sampling has finished,
+  // rather than before? Add another step in the controller thread?
+  ret = accel_self->uart_driver.read(
+      &accel_self->uart_driver, (uint8_t *)&(waves_response[0]),
+      response_length, TX_TIMER_TICKS_PER_SECOND * 60);
+  if (UART_OK != ret) {
+    return uSWIFT_IO_ERROR;
+  }
+  if (0 != strncmp(next_spectra_command, waves_response, 2)) {
+    // TODO: This should be robust to getting different messages; should wait
+    // until it gets a response, and go with that one.
+    // TODO(LEL): Create appropriate error for ACCEL_NO_DATA (separate from the
+    // initialization failure.)
+    return uSWIFT_IO_ERROR;
+  }
+
+  memcpy(priority, &waves_response[2], sizeof(float));
+  memcpy(accel_msg, &waves_response[6], sizeof(sbd_message_type_55));
+  return uSWIFT_SUCCESS;
+}
+
 uSWIFT_return_code_t _accel_self_test(accel_self_test_result_t *result) {
   int32_t ret;
 
@@ -134,7 +175,12 @@ uSWIFT_return_code_t _accel_self_test(accel_self_test_result_t *result) {
 
   // The slowest we'll run is 4Hz, so need to wait long enough for the next
   // sample to arrive. Half a second was too short.
-  uint32_t read_timeout = TX_TIMER_TICKS_PER_SECOND;
+  // And, now that we're supporting continuous mode, this needs to be long
+  // enough that if we call for a self test in the middle of writing to disk
+  // it'll have time to reply. (For now, the accelerometer is single-threaded;
+  //  we may need to split the spectra + filesystem operations into separate
+  // threads.)
+  uint32_t read_timeout = 3 * TX_TIMER_TICKS_PER_SECOND;
   static int response_length = 2 + sizeof(accel_self_test_result_t);
   char self_test_response[response_length];
   memset(self_test_response, 0, response_length);

--- a/Core/Components/Src/accelerometer.c
+++ b/Core/Components/Src/accelerometer.c
@@ -18,7 +18,7 @@ uSWIFT_return_code_t _accel_start_continuous(void);
 uSWIFT_return_code_t _accel_parse_waves(sbd_message_type_55 *accel_msg,
                                         float *priority);
 uSWIFT_return_code_t _accel_next_spectra(sbd_message_type_55 *accel_msg,
-                                         float *priority);
+                                         float *priority, float threshold);
 uSWIFT_return_code_t _accel_uart_init(void);
 uSWIFT_return_code_t _accel_uart_deinit(void);
 uSWIFT_return_code_t _accel_uart_reset(void);
@@ -125,13 +125,15 @@ uSWIFT_return_code_t _accel_parse_waves(sbd_message_type_55 *accel_msg,
 }
 
 uSWIFT_return_code_t _accel_next_spectra(sbd_message_type_55 *accel_msg,
-                                         float *priority) {
-  const char *next_spectra_command = "NS";
+                                         float *priority, float threshold) {
+  char next_spectra_command[6];
+  strcpy(next_spectra_command, "NS");
+  memcpy(&next_spectra_command[2], &threshold, sizeof(float));
 
   UINT ret;
-  ret = accel_self->uart_driver.write(
-      &accel_self->uart_driver, (uint8_t *)&(next_spectra_command[0]),
-      strlen(next_spectra_command), ACCEL_MAX_UART_TX_TICKS);
+  ret = accel_self->uart_driver.write(&accel_self->uart_driver,
+                                      (uint8_t *)&(next_spectra_command[0]), 6,
+                                      ACCEL_MAX_UART_TX_TICKS);
   if (UART_OK != ret) {
     return uSWIFT_IO_ERROR;
   }
@@ -139,9 +141,9 @@ uSWIFT_return_code_t _accel_next_spectra(sbd_message_type_55 *accel_msg,
   static int response_length = 6 + 340;
   char waves_response[response_length];
   memset(waves_response, 0, response_length);
-  // Blocking read for up to 1 minute so other background processing can finish.
-  // This only grabs spectra that are ready (and is typically called at the end
-  // of the duty cycle)
+  // Blocking read for up to 1 minute so other background processing can finish,
+  // since the accel board is currently single-threaded. This only grabs spectra
+  // that are ready (and is typically called at the end of the duty cycle)
   ret = accel_self->uart_driver.read(
       &accel_self->uart_driver, (uint8_t *)&(waves_response[0]),
       response_length, TX_TIMER_TICKS_PER_SECOND * 60);

--- a/Core/Components/Src/accelerometer.c
+++ b/Core/Components/Src/accelerometer.c
@@ -14,7 +14,8 @@ Accelerometer *accel_self;
 uSWIFT_return_code_t _accel_self_test(accel_self_test_result_t *result);
 uSWIFT_return_code_t _accel_set_time(uint32_t timestamp);
 uSWIFT_return_code_t _accel_start_sampling(void);
-uSWIFT_return_code_t _accel_parse_waves(sbd_message_type_55 *accel_msg);
+uSWIFT_return_code_t _accel_parse_waves(sbd_message_type_55 *accel_msg,
+                                        float *priority);
 uSWIFT_return_code_t _accel_uart_init(void);
 uSWIFT_return_code_t _accel_uart_deinit(void);
 uSWIFT_return_code_t _accel_uart_reset(void);
@@ -77,12 +78,13 @@ uSWIFT_return_code_t _accel_start_sampling(void) {
   return uSWIFT_SUCCESS;
 }
 
-uSWIFT_return_code_t _accel_parse_waves(sbd_message_type_55 *accel_msg) {
+uSWIFT_return_code_t _accel_parse_waves(sbd_message_type_55 *accel_msg,
+                                        float *priority) {
   // TODO: It'd probably be cleaner to add some sentinel bytes to the start of
   // the struct, rather than having transmit and receive sides doing this.
   const char *start_sampling_command = "RW";
 
-  static int response_length = 2 + 340;
+  static int response_length = 6 + 340;
   char waves_response[response_length];
   memset(waves_response, 0, response_length);
   // Blocking read for 19 minutes (at 3.9 Hz, 4096 samples is 17.5 minutes)
@@ -100,7 +102,8 @@ uSWIFT_return_code_t _accel_parse_waves(sbd_message_type_55 *accel_msg) {
     return uSWIFT_IO_ERROR;
   }
 
-  memcpy(accel_msg, &waves_response[2], sizeof(sbd_message_type_55));
+  memcpy(priority, &waves_response[2], sizeof(float));
+  memcpy(accel_msg, &waves_response[6], sizeof(sbd_message_type_55));
   return uSWIFT_SUCCESS;
 }
 

--- a/Core/Components/Src/accelerometer.c
+++ b/Core/Components/Src/accelerometer.c
@@ -13,7 +13,8 @@ Accelerometer *accel_self;
 // include them in .h file
 uSWIFT_return_code_t _accel_self_test(accel_self_test_result_t *result);
 uSWIFT_return_code_t _accel_set_time(uint32_t timestamp);
-uSWIFT_return_code_t _accel_start_sampling(void);
+uSWIFT_return_code_t _accel_run_once(void);
+uSWIFT_return_code_t _accel_start_continuous(void);
 uSWIFT_return_code_t _accel_parse_waves(sbd_message_type_55 *accel_msg,
                                         float *priority);
 uSWIFT_return_code_t _accel_uart_init(void);
@@ -28,7 +29,8 @@ void accelerometer_init(Accelerometer *accel, UART_HandleTypeDef *uart_handle,
 
   accel_self->self_test = _accel_self_test;
   accel_self->set_time = _accel_set_time;
-  accel_self->start_sampling = _accel_start_sampling;
+  accel_self->run_once = _accel_run_once;
+  accel_self->start_continuous = _accel_start_continuous;
   accel_self->parse_waves = _accel_parse_waves;
 
   accel_self->uart_init = _accel_uart_init;
@@ -66,12 +68,24 @@ uSWIFT_return_code_t _accel_set_time(uint32_t timestamp) {
   return uSWIFT_SUCCESS;
 }
 
-uSWIFT_return_code_t _accel_start_sampling(void) {
-  const char *start_sampling_command = "RW";
+uSWIFT_return_code_t _accel_run_once(void) {
+  const char *run_once_command = "RW";
   UINT ret;
   ret = accel_self->uart_driver.write(
-      &accel_self->uart_driver, (uint8_t *)&(start_sampling_command[0]),
-      strlen(start_sampling_command), ACCEL_MAX_UART_TX_TICKS);
+      &accel_self->uart_driver, (uint8_t *)&(run_once_command[0]),
+      strlen(run_once_command), ACCEL_MAX_UART_TX_TICKS);
+  if (UART_OK != ret) {
+    return uSWIFT_IO_ERROR;
+  }
+  return uSWIFT_SUCCESS;
+}
+
+uSWIFT_return_code_t _accel_start_continuous(void) {
+  const char *start_continuous_command = "MC";
+  UINT ret;
+  ret = accel_self->uart_driver.write(
+      &accel_self->uart_driver, (uint8_t *)&(start_continuous_command[0]),
+      strlen(start_continuous_command), ACCEL_MAX_UART_TX_TICKS);
   if (UART_OK != ret) {
     return uSWIFT_IO_ERROR;
   }
@@ -82,7 +96,7 @@ uSWIFT_return_code_t _accel_parse_waves(sbd_message_type_55 *accel_msg,
                                         float *priority) {
   // TODO: It'd probably be cleaner to add some sentinel bytes to the start of
   // the struct, rather than having transmit and receive sides doing this.
-  const char *start_sampling_command = "RW";
+  const char *run_once_command = "RW";
 
   static int response_length = 6 + 340;
   char waves_response[response_length];
@@ -94,7 +108,7 @@ uSWIFT_return_code_t _accel_parse_waves(sbd_message_type_55 *accel_msg,
   if (UART_OK != ret) {
     return uSWIFT_IO_ERROR;
   }
-  if (0 != strncmp(start_sampling_command, waves_response, 2)) {
+  if (0 != strncmp(run_once_command, waves_response, 2)) {
     // TODO: This should be robust to getting different messages; should wait
     // until it gets a response, and go with that one.
     // TODO(LEL): Create appropriate error for ACCEL_NO_DATA (separate from the

--- a/Core/Components/Src/accelerometer.c
+++ b/Core/Components/Src/accelerometer.c
@@ -140,9 +140,8 @@ uSWIFT_return_code_t _accel_next_spectra(sbd_message_type_55 *accel_msg,
   char waves_response[response_length];
   memset(waves_response, 0, response_length);
   // Blocking read for up to 1 minute so other background processing can finish.
-  // This only grabs spectra that are already ready.
-  // TODO(LEL): Should this query happen AFTER GNSS sampling has finished,
-  // rather than before? Add another step in the controller thread?
+  // This only grabs spectra that are ready (and is typically called at the end
+  // of the duty cycle)
   ret = accel_self->uart_driver.read(
       &accel_self->uart_driver, (uint8_t *)&(waves_response[0]),
       response_length, TX_TIMER_TICKS_PER_SECOND * 60);

--- a/Core/Components/Src/iridium.c
+++ b/Core/Components/Src/iridium.c
@@ -715,7 +715,7 @@ static void __reset_uart(void) {
 static int32_t __uart_read_dma(void *driver_ptr, uint8_t *read_buf,
                                uint16_t size, uint32_t timeout_ticks) {
   generic_uart_driver *driver_handle = (generic_uart_driver *)driver_ptr;
-  LOG("__uart_read_dma requesting %u bytes", size);
+  // LOG("__uart_read_dma requesting %u bytes", size);
 
   HAL_StatusTypeDef rx_result;
   if (iridium_self->receive_to_idle) {
@@ -743,7 +743,7 @@ static int32_t __uart_read_dma(void *driver_ptr, uint8_t *read_buf,
     goto uart_error;
   }
 
-  LOG("...uart_read_dma finished successfully. %s", read_buf);
+  // LOG("...uart_read_dma finished successfully. %s", read_buf);
 
   return UART_OK;
 
@@ -757,7 +757,7 @@ static int32_t __uart_write_dma(void *driver_ptr, uint8_t *write_buf,
                                 uint16_t size, uint32_t timeout_ticks) {
   generic_uart_driver *driver_handle = (generic_uart_driver *)driver_ptr;
 
-  LOG("__uart_write_dma sending %u bytes: %s", size, write_buf);
+  // LOG("__uart_write_dma sending %u bytes: %s", size, write_buf);
   if (HAL_UART_Transmit_DMA(driver_handle->uart_handle, write_buf, size) !=
       HAL_OK) {
     goto uart_error;
@@ -767,13 +767,13 @@ static int32_t __uart_write_dma(void *driver_ptr, uint8_t *write_buf,
     goto uart_error;
   }
 
-  LOG("...uart_write_dma sent successfully");
+  // LOG("...uart_write_dma sent successfully");
   return UART_OK;
 
 uart_error:
   HAL_UART_DMAStop(driver_handle->uart_handle);
   HAL_UART_Abort(driver_handle->uart_handle);
-  LOG("...uart_write_dma failed.");
+  // LOG("...uart_write_dma failed.");
 
   return UART_ERR;
 }

--- a/Core/Inc/configuration.h
+++ b/Core/Inc/configuration.h
@@ -11,14 +11,12 @@
 #include "stdbool.h"
 #include "stdint.h"
 
-typedef struct
-{
-  uint8_t major_rev :3;
-  uint8_t minor_rev :5;
+typedef struct {
+  uint8_t major_rev : 3;
+  uint8_t minor_rev : 5;
 } microSWIFT_firmware_version_t;
 
-typedef struct __attribute__((packed)) microSWIFT_configuration
-{
+typedef struct __attribute__((packed)) microSWIFT_configuration {
   uint32_t tracking_number;
   uint32_t gnss_samples_per_window;
   uint32_t duty_cycle;

--- a/Core/Inc/configuration.h
+++ b/Core/Inc/configuration.h
@@ -35,6 +35,10 @@ typedef struct __attribute__((packed)) microSWIFT_configuration {
   bool light_enabled;
   bool turbidity_enabled;
   bool accelerometer_enabled;
+  // Default for accelerometer is "polled" mode, running one sample
+  // per duty cycle. However, it also supports a "continuous" mode,
+  // where it buffers data and will report the most significant events.
+  bool accelerometer_continuous_sampling;
 
   const char compile_date[11];
   const char compile_time[9];

--- a/Core/Inc/persistent_ram.h
+++ b/Core/Inc/persistent_ram.h
@@ -122,7 +122,8 @@ void persistent_ram_set_rtc_time_set(void);
 bool persistent_ram_get_rtc_time_set(void);
 uint32_t persistent_ram_get_reset_reason(void);
 uint32_t persistent_ram_get_num_msgs_enqueued(telemetry_type_t msg_type);
-void persistent_ram_save_message(telemetry_type_t msg_type, uint8_t *msg);
+void persistent_ram_save_message(telemetry_type_t msg_type, float msg_priority,
+                                 uint8_t *msg);
 uint8_t *
 persistent_ram_get_prioritized_unsent_message(telemetry_type_t msg_type);
 void persistent_ram_delete_message_element(telemetry_type_t msg_type,

--- a/Core/Inc/persistent_ram.h
+++ b/Core/Inc/persistent_ram.h
@@ -147,6 +147,8 @@ uint8_t *
 persistent_ram_get_prioritized_unsent_message(telemetry_type_t msg_type);
 void persistent_ram_delete_message_element(telemetry_type_t msg_type,
                                            uint8_t *msg_ptr);
+void persistent_ram_get_accel_priorities(float *priorities);
+
 // @formatter:on
 
 #endif /* INC_PERSISTENT_RAM_H_ */

--- a/Core/Inc/persistent_ram.h
+++ b/Core/Inc/persistent_ram.h
@@ -37,22 +37,35 @@ typedef struct {
   bool valid;
 } Accelerometer_Message_Storage_Element_t;
 
-// NB: This max does not change based on which sensors are enabled; currently
-//     evaluates to ~16 messages (or several days of waves messages), so that
-//     limitation may not be particularly important.
-#define MAX_NUM_NON_WAVES_MSGS_STORED                                          \
-  (65536U / ((sizeof(Iridium_Message_Storage_Element_t) * 5U) +                \
-             sizeof(Turbidity_Message_Storage_Element_t) +                     \
-             sizeof(Light_Message_Storage_Element_t) +                         \
-             sizeof(Accelerometer_Message_Storage_Element_t) *                 \
-                 5U)) // Max possible based on 64K SRAM2 size
+// NB: We do not change memory allocation based on which sensors are enabled,
+//     so some of this may be unused.
+// We have 64KB available in .sram2 for persistent storage
 
-#define MAX_NUM_WAVES_MSGS_STORED (MAX_NUM_NON_WAVES_MSGS_STORED * 5U)
-#define MAX_NUM_ACCELEROMETER_MSGS_STORED (MAX_NUM_NON_WAVES_MSGS_STORED * 5U)
+// MAX_NUM_NON_WAVES_MSGS_STORED Originally set to 16, by assuming that
+// we'd store an equal number of waves and accel messages, and that
+// we'd store 5x more waves than light or turbidity
+//
+// I'd rather tune that manually, and have the numbers explicitly defined.
+//
+// sizeof(Iridium_Message_Storage_Element_t) = 340
+// sizeof(Accelerometer_Message_Storage_Element_t) = 344
+// sizeof(Turbidity_Message_Storage_Element_t) = 288  (fits 3 turbidity msgs)
+// sizeof(Light_Message_Storage_Element_t) = 337 (fits 6 turbidity msgs)
+// total bytes used must be <= 65535U
+// with 80x waves; 80x accel; 16x each non_waves, we're at 63.65 KB
+// (360 bytes free)
+#define MAX_NUM_WAVES_MSGS_STORED 80
+#define MAX_NUM_ACCELEROMETER_MSGS_STORED 80
+
+// At least for now, these are coupled (code uses aggregated SBD msgs
+// stored vs. total Turbidity/Light message elements stored in different
+// loops.
+#define MAX_NUM_NON_WAVES_MSGS_STORED 16
 #define MAX_NUM_TURBIDITY_MSGS_STORED                                          \
   (MAX_NUM_NON_WAVES_MSGS_STORED * TURBIDITY_MSGS_PER_SBD)
 #define MAX_NUM_LIGHT_MSGS_STORED                                              \
   (MAX_NUM_NON_WAVES_MSGS_STORED * LIGHT_MSGS_PER_SBD)
+
 typedef struct {
   Iridium_Message_Storage_Element_t msg_queue[MAX_NUM_WAVES_MSGS_STORED];
   uint32_t num_telemetry_msgs_enqueued;

--- a/Core/Inc/persistent_ram.h
+++ b/Core/Inc/persistent_ram.h
@@ -8,124 +8,125 @@
 #ifndef INC_PERSISTENT_RAM_H_
 #define INC_PERSISTENT_RAM_H_
 
-#include "stdbool.h"
-#include "stddef.h"
-#include "sbd.h"
 #include "NEDWaves/rtwhalf.h"
 #include "configuration.h"
+#include "sbd.h"
+#include "stdbool.h"
+#include "stddef.h"
 
 #define PERSISTENT_RAM_MAGIC_DOUBLE_WORD 0x5048494C42555348
 
 // @formatter:off
-typedef struct
-{
-  sbd_message_type_52       payload;
-  bool                      valid;
+typedef struct {
+  sbd_message_type_52 payload;
+  bool valid;
 } Iridium_Message_Storage_Element_t;
 
-typedef struct
-{
-  sbd_message_type_53       payload;
-  bool                      valid[TURBIDITY_MSGS_PER_SBD];
+typedef struct {
+  sbd_message_type_53 payload;
+  bool valid[TURBIDITY_MSGS_PER_SBD];
 } Turbidity_Message_Storage_Element_t;
 
-typedef struct
-{
-  sbd_message_type_54       payload;
-  bool                      valid[LIGHT_MSGS_PER_SBD];
+typedef struct {
+  sbd_message_type_54 payload;
+  bool valid[LIGHT_MSGS_PER_SBD];
 } Light_Message_Storage_Element_t;
 
-typedef struct
-{
-  sbd_message_type_55       payload;
-  bool                      valid;
-  } Accelerometer_Message_Storage_Element_t;
+typedef struct {
+  sbd_message_type_55 payload;
+  bool valid;
+} Accelerometer_Message_Storage_Element_t;
 
 // NB: This max does not change based on which sensors are enabled; currently
 //     evaluates to ~16 messages (or several days of waves messages), so that
 //     limitation may not be particularly important.
-#define MAX_NUM_NON_WAVES_MSGS_STORED   (65536U / ((sizeof(Iridium_Message_Storage_Element_t) * 5U) \
-                                         + sizeof(Turbidity_Message_Storage_Element_t) \
-                                         + sizeof(Light_Message_Storage_Element_t) \
-                                         + sizeof(Accelerometer_Message_Storage_Element_t) * 5U)) // Max possible based on 64K SRAM2 size
+#define MAX_NUM_NON_WAVES_MSGS_STORED                                          \
+  (65536U / ((sizeof(Iridium_Message_Storage_Element_t) * 5U) +                \
+             sizeof(Turbidity_Message_Storage_Element_t) +                     \
+             sizeof(Light_Message_Storage_Element_t) +                         \
+             sizeof(Accelerometer_Message_Storage_Element_t) *                 \
+                 5U)) // Max possible based on 64K SRAM2 size
 
-#define MAX_NUM_WAVES_MSGS_STORED       (MAX_NUM_NON_WAVES_MSGS_STORED * 5U)
+#define MAX_NUM_WAVES_MSGS_STORED (MAX_NUM_NON_WAVES_MSGS_STORED * 5U)
 #define MAX_NUM_ACCELEROMETER_MSGS_STORED (MAX_NUM_NON_WAVES_MSGS_STORED * 5U)
-#define MAX_NUM_TURBIDITY_MSGS_STORED   (MAX_NUM_NON_WAVES_MSGS_STORED * TURBIDITY_MSGS_PER_SBD)
-#define MAX_NUM_LIGHT_MSGS_STORED       (MAX_NUM_NON_WAVES_MSGS_STORED * LIGHT_MSGS_PER_SBD)
-typedef struct
-{
-  Iridium_Message_Storage_Element_t     msg_queue[MAX_NUM_WAVES_MSGS_STORED];
-  uint32_t                              num_telemetry_msgs_enqueued;
+#define MAX_NUM_TURBIDITY_MSGS_STORED                                          \
+  (MAX_NUM_NON_WAVES_MSGS_STORED * TURBIDITY_MSGS_PER_SBD)
+#define MAX_NUM_LIGHT_MSGS_STORED                                              \
+  (MAX_NUM_NON_WAVES_MSGS_STORED * LIGHT_MSGS_PER_SBD)
+typedef struct {
+  Iridium_Message_Storage_Element_t msg_queue[MAX_NUM_WAVES_MSGS_STORED];
+  uint32_t num_telemetry_msgs_enqueued;
 } Waves_Message_Storage;
 
-typedef struct
-{
-  Turbidity_Message_Storage_Element_t   msg_queue[MAX_NUM_NON_WAVES_MSGS_STORED];
-  uint32_t                              num_msg_elements_enqueued;
-  uint32_t                              current_msg_index;
+typedef struct {
+  Turbidity_Message_Storage_Element_t msg_queue[MAX_NUM_NON_WAVES_MSGS_STORED];
+  uint32_t num_msg_elements_enqueued;
+  uint32_t current_msg_index;
 } Turbidity_Message_Storage;
 
-typedef struct
-{
-  Light_Message_Storage_Element_t       msg_queue[MAX_NUM_NON_WAVES_MSGS_STORED];
-  uint32_t                              num_msg_elements_enqueued;
-  uint32_t                              current_msg_index;
+typedef struct {
+  Light_Message_Storage_Element_t msg_queue[MAX_NUM_NON_WAVES_MSGS_STORED];
+  uint32_t num_msg_elements_enqueued;
+  uint32_t current_msg_index;
 } Light_Message_Storage;
 
-typedef struct
-{
-  Accelerometer_Message_Storage_Element_t msg_queue[MAX_NUM_ACCELEROMETER_MSGS_STORED];
+typedef struct {
+  Accelerometer_Message_Storage_Element_t
+      msg_queue[MAX_NUM_ACCELEROMETER_MSGS_STORED];
   uint32_t num_telemetry_msgs_enqueued;
 } Accelerometer_Message_Storage;
 
 // All of the things we need to retain in standby mode
-typedef struct
-{
-  uint64_t                      magic_number;
-  int32_t                       sample_window_counter;
-  uint32_t                      reset_reason;
-  bool                          rtc_time_set;
-  bool                          ota_update_received;
-  bool                          ota_acknowledgement_sent;
-  sbd_message_type_99           ota_acknowledgement_msg;
-  Waves_Message_Storage         waves_storage;
-  Turbidity_Message_Storage     turbidity_storage;
-  Light_Message_Storage         light_storage;
+typedef struct {
+  uint64_t magic_number;
+  int32_t sample_window_counter;
+  uint32_t reset_reason;
+  bool rtc_time_set;
+  bool ota_update_received;
+  bool ota_acknowledgement_sent;
+  sbd_message_type_99 ota_acknowledgement_msg;
+  Waves_Message_Storage waves_storage;
+  Turbidity_Message_Storage turbidity_storage;
+  Light_Message_Storage light_storage;
   Accelerometer_Message_Storage accelerometer_storage;
-  microSWIFT_configuration      device_config;
+  microSWIFT_configuration device_config;
   microSWIFT_firmware_version_t version;
 } Persistent_Storage;
 
-typedef enum
-{
-  WAVES_TELEMETRY         = 0,
-  TURBIDITY_TELEMETRY     = 1,
-  LIGHT_TELEMETRY         = 2,
+typedef enum {
+  WAVES_TELEMETRY = 0,
+  TURBIDITY_TELEMETRY = 1,
+  LIGHT_TELEMETRY = 2,
   ACCELEROMETER_TELEMETRY = 3,
-  OTA_ACK_MESSAGE         = 4,
-  NO_MESSAGE              = 5
+  OTA_ACK_MESSAGE = 4,
+  NO_MESSAGE = 5
 } telemetry_type_t;
 
-void                    persistent_ram_init ( const microSWIFT_configuration *config, const microSWIFT_firmware_version_t *version );
-void                    persistent_ram_deinit ( void );
-void                    persistent_ram_set_device_config ( const microSWIFT_configuration *config, bool ota_update );
-void                    persistent_ram_get_device_config ( microSWIFT_configuration *config );
-void                    persistent_ram_set_firmware_version ( const microSWIFT_firmware_version_t *version );
-void                    persistent_ram_get_firmware_version ( microSWIFT_firmware_version_t *version );
-bool                    persistent_ram_get_ota_update_status ( void );
-bool                    persistent_ram_get_ota_ack_status ( void );
-void                    persistent_ram_set_ota_ack_msg ( sbd_message_type_99 *msg );
-void                    persistent_ram_get_ota_ack_msg ( sbd_message_type_99 *msg );
-uint32_t                persistent_ram_get_sample_window_counter ( void );
-void                    persistent_ram_reset_sample_window_counter ( void );
-void                    persistent_ram_set_rtc_time_set ( void );
-bool                    persistent_ram_get_rtc_time_set ( void );
-uint32_t                persistent_ram_get_reset_reason ( void );
-uint32_t                persistent_ram_get_num_msgs_enqueued ( telemetry_type_t msg_type );
-void                    persistent_ram_save_message ( telemetry_type_t msg_type, uint8_t* msg );
-uint8_t*                persistent_ram_get_prioritized_unsent_message ( telemetry_type_t msg_type );
-void                    persistent_ram_delete_message_element ( telemetry_type_t msg_type, uint8_t *msg_ptr );
+void persistent_ram_init(const microSWIFT_configuration *config,
+                         const microSWIFT_firmware_version_t *version);
+void persistent_ram_deinit(void);
+void persistent_ram_set_device_config(const microSWIFT_configuration *config,
+                                      bool ota_update);
+void persistent_ram_get_device_config(microSWIFT_configuration *config);
+void persistent_ram_set_firmware_version(
+    const microSWIFT_firmware_version_t *version);
+void persistent_ram_get_firmware_version(
+    microSWIFT_firmware_version_t *version);
+bool persistent_ram_get_ota_update_status(void);
+bool persistent_ram_get_ota_ack_status(void);
+void persistent_ram_set_ota_ack_msg(sbd_message_type_99 *msg);
+void persistent_ram_get_ota_ack_msg(sbd_message_type_99 *msg);
+uint32_t persistent_ram_get_sample_window_counter(void);
+void persistent_ram_reset_sample_window_counter(void);
+void persistent_ram_set_rtc_time_set(void);
+bool persistent_ram_get_rtc_time_set(void);
+uint32_t persistent_ram_get_reset_reason(void);
+uint32_t persistent_ram_get_num_msgs_enqueued(telemetry_type_t msg_type);
+void persistent_ram_save_message(telemetry_type_t msg_type, uint8_t *msg);
+uint8_t *
+persistent_ram_get_prioritized_unsent_message(telemetry_type_t msg_type);
+void persistent_ram_delete_message_element(telemetry_type_t msg_type,
+                                           uint8_t *msg_ptr);
 // @formatter:on
 
 #endif /* INC_PERSISTENT_RAM_H_ */

--- a/Core/Inc/persistent_ram.h
+++ b/Core/Inc/persistent_ram.h
@@ -19,7 +19,7 @@
 // @formatter:off
 typedef struct {
   sbd_message_type_52 payload;
-  bool valid;
+  float priority;
 } Iridium_Message_Storage_Element_t;
 
 typedef struct {
@@ -34,7 +34,13 @@ typedef struct {
 
 typedef struct {
   sbd_message_type_55 payload;
-  bool valid;
+  // We're treating this as a priority queue; I'd rather calculate priority
+  // once, rather than re-calculating each time we need to insert something
+  // into the queue.
+  //
+  // Sum of X/Y/Z spectra amplitudes across all frequencies
+  // -FLT_MAX if message has already been sent or has not been populated.
+  float priority;
 } Accelerometer_Message_Storage_Element_t;
 
 // NB: We do not change memory allocation based on which sensors are enabled,
@@ -101,7 +107,7 @@ typedef struct {
   Waves_Message_Storage waves_storage;
   Turbidity_Message_Storage turbidity_storage;
   Light_Message_Storage light_storage;
-  Accelerometer_Message_Storage accelerometer_storage;
+  Accelerometer_Message_Storage accel_storage;
   microSWIFT_configuration device_config;
   microSWIFT_firmware_version_t version;
 } Persistent_Storage;

--- a/Core/Src/app_threadx.c
+++ b/Core/Src/app_threadx.c
@@ -2226,7 +2226,11 @@ static void accel_thread_entry(ULONG thread_input) {
 
   // If we send a second UART command immediately, it won't be received.
   tx_thread_sleep(TX_TIMER_TICKS_PER_SECOND);
-  accel.start_sampling();
+  if (configuration.accelerometer_continuous_sampling) {
+    accel.start_continuous();
+  } else {
+    accel.run_once();
+  }
 
   LOG("Accelerometer sample window started.");
   sbd_message_type_55 accel_msg = {0};

--- a/Core/Src/app_threadx.c
+++ b/Core/Src/app_threadx.c
@@ -2228,12 +2228,13 @@ static void accel_thread_entry(ULONG thread_input) {
 
   LOG("Accelerometer sample window started.");
   sbd_message_type_55 accel_msg = {0};
+  float priority;
 
   // TODO: Set timeout for overall thread:
   //   e.g.   iridium.start_timer(iridium_thread_timeout);
 
   // Read bytes; package up and add to iridium queue.
-  ret = accel.parse_waves(&accel_msg);
+  ret = accel.parse_waves(&accel_msg, &priority);
   if (uSWIFT_SUCCESS != ret) {
     accel_error_out(&accel, ACCELEROMETER_SAMPLING_ERROR, this_thread,
                     "Acceleration-based waves returned with error code: %d",
@@ -2260,7 +2261,7 @@ static void accel_thread_entry(ULONG thread_input) {
   memcpy(&accel_msg.latitude, &msg_lat, sizeof(float));
   memcpy(&accel_msg.longitude, &msg_lon, sizeof(float));
 
-  LOG("Received accelerometer message:");
+  LOG("Received accelerometer message w/ priority %0.6f:", priority);
   LOG("....time.: %ul", accel_msg.timestamp);
   LOG("....X min/mean/max: %0.4f / %0.4f / %0.4f",
       halfToFloat(accel_msg.min_x_accel), halfToFloat(accel_msg.mean_x_accel),
@@ -2273,9 +2274,7 @@ static void accel_thread_entry(ULONG thread_input) {
       halfToFloat(accel_msg.max_z_accel));
   LOG("Lat = %0.2f, Lon = %0.2f", accel_msg.latitude, accel_msg.longitude);
 
-  // TODO: Replace this with the sum-of-spectra that Jim requested
-  float accel_msg_priority = fabsf(halfToFloat(accel_msg.max_z_accel));
-  persistent_ram_save_message(ACCELEROMETER_TELEMETRY, accel_msg_priority,
+  persistent_ram_save_message(ACCELEROMETER_TELEMETRY, priority,
                               (uint8_t *)&accel_msg);
 
   // TODO: Add saving the data. I'm not yet sure whether we need a whole

--- a/Core/Src/app_threadx.c
+++ b/Core/Src/app_threadx.c
@@ -2213,7 +2213,7 @@ static void accel_thread_entry(ULONG thread_input) {
 
   tx_thread_sleep(TX_TIMER_TICKS_PER_SECOND / 10);
 
-  LOG("Resuming accelerometer thread");
+  LOG("Resuming accelerometer thread (after self test)");
   accel.power_on();
   ret = usart2_init();
   if (UART_OK != ret) {
@@ -2234,11 +2234,12 @@ static void accel_thread_entry(ULONG thread_input) {
   tx_thread_sleep(TX_TIMER_TICKS_PER_SECOND);
   if (configuration.accelerometer_continuous_sampling) {
     accel.start_continuous();
+    LOG("Accelerometer sample window started in continuous mode.");
   } else {
     accel.run_once();
+    LOG("Accelerometer sample window started in single sample mode.");
   }
 
-  LOG("Accelerometer sample window started.");
   sbd_message_type_55 accel_msg = {0};
   float priority;
 
@@ -2246,6 +2247,15 @@ static void accel_thread_entry(ULONG thread_input) {
   //   e.g.   iridium.start_timer(iridium_thread_timeout);
 
   if (configuration.accelerometer_continuous_sampling) {
+    // Suspend for now, will be woken up 2 minutes before end of GNSS period
+    tx_thread_suspend(this_thread);
+
+    // If the GNSS thread has completed with errors, may have been woken back
+    // up almost instantly after suspending. Give the Accelerometer board
+    // time to at least start a sampling period, though it'll only finish if
+    // the rate is fast and we're collecting few samples.
+    tx_thread_sleep(5 * TX_TIMER_TICKS_PER_SECOND);
+    LOG("Accelerometer thread resumed in order to query spectra.");
 
     // TODO: For the continuous method, want to request data from accelerometer
     // card until top N spots in queue are true max across both
@@ -2257,8 +2267,12 @@ static void accel_thread_entry(ULONG thread_input) {
                         "Acceleration-based waves returned with error code: %d",
                         (int)ret);
       }
-      LOG("Received accel spectra #%d", ii);
-      save_accel_sbd(&accel_msg, priority);
+      LOG("Received accel spectra #%d with priority %0.6f", ii, priority);
+      if (priority < 0) {
+        LOG("Returned priority < 0; no spectra available from accel board.");
+      } else {
+        save_accel_sbd(&accel_msg, priority);
+      }
     }
     accel.uart_deinit();
 
@@ -2270,11 +2284,9 @@ static void accel_thread_entry(ULONG thread_input) {
                       "Acceleration-based waves returned with error code: %d",
                       (int)ret);
     }
-
     LOG("Accelerometer-based waves computations completed.");
     accel.uart_deinit();
     accel.power_off();
-
     save_accel_sbd(&accel_msg, priority);
   }
 

--- a/Core/Src/app_threadx.c
+++ b/Core/Src/app_threadx.c
@@ -48,6 +48,7 @@
 #include "string.h"
 #include "temp_sensor.h"
 #include "turbidity_sensor.h"
+#include <float.h>
 #include <math.h>
 
 #include "NEDWaves/test_data_includes.h"
@@ -236,6 +237,7 @@ static void accel_thread_entry(ULONG thread_input);
 // I didn't move it into accelerometer.c because it depends on
 // functions in gnss.h, and I didn't want to add that dependencyb.
 static void save_accel_sbd(sbd_message_type_55 *accel_msg, float priority);
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
 
 // clang-format off
 /* USER CODE END PFP */
@@ -2260,8 +2262,23 @@ static void accel_thread_entry(ULONG thread_input) {
     // TODO: For the continuous method, want to request data from accelerometer
     // card until top N spots in queue are true max across both
     // microcontrollers.
-    for (int ii = 0; ii < 3; ii++) {
-      ret = accel.next_spectra(&accel_msg, &priority);
+    float priorities[MAX_NUM_ACCELEROMETER_MSGS_STORED];
+    // Find the top N priorities
+    int nn = MIN(MAX_NUM_ACCELEROMETER_MSGS_STORED, 15);
+
+    // Figure out the threshold priority for requesting data from the
+    // accel queue. (We want to wind up with the top N priority spectra
+    // stored in the controller's queue, so don't ask for new data that
+    // wouldn't make the top N)
+
+    for (int ii = 0; ii < nn; ii++) {
+      // Get unsorted priorities from persistent ram.
+      persistent_ram_get_accel_priorities(priorities);
+      sort_top_n(priorities, MAX_NUM_ACCELEROMETER_MSGS_STORED, nn);
+      float threshold_priority = priorities[nn];
+      LOG("Requesting priorities greater than %0.06f", threshold_priority);
+
+      ret = accel.next_spectra(&accel_msg, &priority, threshold_priority);
       if (uSWIFT_SUCCESS != ret) {
         accel_error_out(&accel, ACCELEROMETER_SAMPLING_ERROR, this_thread,
                         "Acceleration-based waves returned with error code: %d",
@@ -2270,6 +2287,7 @@ static void accel_thread_entry(ULONG thread_input) {
       LOG("Received accel spectra #%d with priority %0.6f", ii, priority);
       if (priority < 0) {
         LOG("Returned priority < 0; no spectra available from accel board.");
+        break;
       } else {
         save_accel_sbd(&accel_msg, priority);
       }
@@ -2330,6 +2348,27 @@ void save_accel_sbd(sbd_message_type_55 *accel_msg, float priority) {
 
   persistent_ram_save_message(ACCELEROMETER_TELEMETRY, priority,
                               (uint8_t *)accel_msg);
+}
+
+// Stupid in-place sorting algorithm used to find the N-th highest priority
+// Only reasonable if len(priorities) >> N
+void sort_top_n(float *priorities, int array_len, int num) {
+  float tmp_max;
+  int tmp_max_idx;
+  for (int ii = 0; ii < num; ii++) {
+    tmp_max = -FLT_MAX;
+    tmp_max_idx = -1;
+    // find N-th highest priority, assuming higher ones have been sorted to
+    // front of array.
+    for (int jj = ii; jj < array_len; jj++) {
+      if (priorities[jj] > tmp_max) {
+        tmp_max = priorities[jj];
+        tmp_max_idx = jj;
+      }
+    }
+    priorities[tmp_max_idx] = priorities[ii];
+    priorities[ii] = tmp_max;
+  }
 }
 // clang-format off
 /* USER CODE END 1 */

--- a/Core/Src/app_threadx.c
+++ b/Core/Src/app_threadx.c
@@ -238,6 +238,7 @@ static void accel_thread_entry(ULONG thread_input);
 // functions in gnss.h, and I didn't want to add that dependencyb.
 static void save_accel_sbd(sbd_message_type_55 *accel_msg, float priority);
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
+void sort_top_n(float *priorities, int array_len, int num);
 
 // clang-format off
 /* USER CODE END PFP */

--- a/Core/Src/app_threadx.c
+++ b/Core/Src/app_threadx.c
@@ -232,6 +232,10 @@ static void temperature_thread_entry(ULONG thread_input);
 static void light_thread_entry(ULONG thread_input);
 static void turbidity_thread_entry(ULONG thread_input);
 static void accel_thread_entry(ULONG thread_input);
+// Helper function for accel_thread.
+// I didn't move it into accelerometer.c because it depends on
+// functions in gnss.h, and I didn't want to add that dependencyb.
+static void save_accel_sbd(sbd_message_type_55 *accel_msg, float priority);
 
 // clang-format off
 /* USER CODE END PFP */
@@ -2200,7 +2204,9 @@ static void accel_thread_entry(ULONG thread_input) {
   tx_thread_sleep(10 * TX_TIMER_TICKS_PER_SECOND);
 
   ret = usart2_deinit();
-  accel.power_off();
+  if (!configuration.accelerometer_continuous_sampling) {
+    accel.power_off();
+  }
 
   // Suspend for now, will be woken up when GNSS has initialized
   tx_thread_suspend(this_thread);
@@ -2239,18 +2245,48 @@ static void accel_thread_entry(ULONG thread_input) {
   // TODO: Set timeout for overall thread:
   //   e.g.   iridium.start_timer(iridium_thread_timeout);
 
-  // Read bytes; package up and add to iridium queue.
-  ret = accel.parse_waves(&accel_msg, &priority);
-  if (uSWIFT_SUCCESS != ret) {
-    accel_error_out(&accel, ACCELEROMETER_SAMPLING_ERROR, this_thread,
-                    "Acceleration-based waves returned with error code: %d",
-                    (int)ret);
+  if (configuration.accelerometer_continuous_sampling) {
+
+    // TODO: For the continuous method, want to request data from accelerometer
+    // card until top N spots in queue are true max across both
+    // microcontrollers.
+    for (int ii = 0; ii < 3; ii++) {
+      ret = accel.next_spectra(&accel_msg, &priority);
+      if (uSWIFT_SUCCESS != ret) {
+        accel_error_out(&accel, ACCELEROMETER_SAMPLING_ERROR, this_thread,
+                        "Acceleration-based waves returned with error code: %d",
+                        (int)ret);
+      }
+      LOG("Received accel spectra #%d", ii);
+      save_accel_sbd(&accel_msg, priority);
+    }
+    accel.uart_deinit();
+
+  } else {
+    // Read bytes; package up and add to iridium queue.^M
+    ret = accel.parse_waves(&accel_msg, &priority);
+    if (uSWIFT_SUCCESS != ret) {
+      accel_error_out(&accel, ACCELEROMETER_SAMPLING_ERROR, this_thread,
+                      "Acceleration-based waves returned with error code: %d",
+                      (int)ret);
+    }
+
+    LOG("Accelerometer-based waves computations completed.");
+    accel.uart_deinit();
+    accel.power_off();
+
+    save_accel_sbd(&accel_msg, priority);
   }
 
-  LOG("Accelerometer-based waves computations completed.");
-  accel.uart_deinit();
-  accel.power_off();
+  tx_thread_sleep(LOGGER_MAX_TICKS_TO_TX_MSG);
 
+  (void)tx_event_flags_set(&complete_flags,
+                           ACCELEROMETER_THREAD_COMPLETED_SUCCESSFULLY, TX_OR);
+  tx_thread_terminate(this_thread);
+}
+
+// Populate message with lat/lon, and add to persistent RAM
+void save_accel_sbd(sbd_message_type_55 *accel_msg, float priority) {
   char ascii_7 = '7';
   uint8_t accel_type = 55;
   int32_t lat = 0;
@@ -2262,38 +2298,26 @@ static void accel_thread_entry(ULONG thread_input) {
   msg_lat = (float)lat / LAT_LON_CONVERSION_FACTOR;
   msg_lon = (float)lon / LAT_LON_CONVERSION_FACTOR;
 
-  memcpy(&accel_msg.legacy_number_7, &ascii_7, sizeof(uint8_t));
-  memcpy(&accel_msg.type, &accel_type, sizeof(uint8_t));
-  memcpy(&accel_msg.latitude, &msg_lat, sizeof(float));
-  memcpy(&accel_msg.longitude, &msg_lon, sizeof(float));
+  memcpy(&accel_msg->legacy_number_7, &ascii_7, sizeof(uint8_t));
+  memcpy(&accel_msg->type, &accel_type, sizeof(uint8_t));
+  memcpy(&accel_msg->latitude, &msg_lat, sizeof(float));
+  memcpy(&accel_msg->longitude, &msg_lon, sizeof(float));
 
   LOG("Received accelerometer message w/ priority %0.6f:", priority);
-  LOG("....time.: %ul", accel_msg.timestamp);
+  LOG("....time.: %ul", accel_msg->timestamp);
   LOG("....X min/mean/max: %0.4f / %0.4f / %0.4f",
-      halfToFloat(accel_msg.min_x_accel), halfToFloat(accel_msg.mean_x_accel),
-      halfToFloat(accel_msg.max_x_accel));
+      halfToFloat(accel_msg->min_x_accel), halfToFloat(accel_msg->mean_x_accel),
+      halfToFloat(accel_msg->max_x_accel));
   LOG("....Y min/mean/max: %0.4f / %0.4f / %0.4f",
-      halfToFloat(accel_msg.min_y_accel), halfToFloat(accel_msg.mean_y_accel),
-      halfToFloat(accel_msg.max_y_accel));
+      halfToFloat(accel_msg->min_y_accel), halfToFloat(accel_msg->mean_y_accel),
+      halfToFloat(accel_msg->max_y_accel));
   LOG("....Z min/mean/max: %0.4f / %0.4f / %0.4f",
-      halfToFloat(accel_msg.min_z_accel), halfToFloat(accel_msg.mean_z_accel),
-      halfToFloat(accel_msg.max_z_accel));
-  LOG("Lat = %0.2f, Lon = %0.2f", accel_msg.latitude, accel_msg.longitude);
+      halfToFloat(accel_msg->min_z_accel), halfToFloat(accel_msg->mean_z_accel),
+      halfToFloat(accel_msg->max_z_accel));
+  LOG("Lat = %0.2f, Lon = %0.2f", accel_msg->latitude, accel_msg->longitude);
 
   persistent_ram_save_message(ACCELEROMETER_TELEMETRY, priority,
-                              (uint8_t *)&accel_msg);
-
-  // TODO: Add saving the data. I'm not yet sure whether we need a whole
-  //       struct to hold the accelerometer-related variables ...
-  //    Of course, this woudldn't be true raw data, just the chunk
-  //    that is sent
-  // (void)file_system_server_save_accelerometer_raw(&accel);
-
-  tx_thread_sleep(LOGGER_MAX_TICKS_TO_TX_MSG);
-
-  (void)tx_event_flags_set(&complete_flags,
-                           ACCELEROMETER_THREAD_COMPLETED_SUCCESSFULLY, TX_OR);
-  tx_thread_terminate(this_thread);
+                              (uint8_t *)accel_msg);
 }
 // clang-format off
 /* USER CODE END 1 */

--- a/Core/Src/app_threadx.c
+++ b/Core/Src/app_threadx.c
@@ -2290,6 +2290,11 @@ static void accel_thread_entry(ULONG thread_input) {
         LOG("Returned priority < 0; no spectra available from accel board.");
         break;
       } else {
+        if (priority < threshold_priority) {
+          LOG("Error in prioritization! Received spectra with valid priority "
+              "(%0.6f) but less than requested threshold (%0.6f)! ",
+              priority, threshold_priority);
+        }
         save_accel_sbd(&accel_msg, priority);
       }
     }
@@ -2335,17 +2340,20 @@ void save_accel_sbd(sbd_message_type_55 *accel_msg, float priority) {
   memcpy(&accel_msg->longitude, &msg_lon, sizeof(float));
 
   LOG("Received accelerometer message w/ priority %0.6f:", priority);
-  LOG("....time.: %ul", accel_msg->timestamp);
-  LOG("....X min/mean/max: %0.4f / %0.4f / %0.4f",
-      halfToFloat(accel_msg->min_x_accel), halfToFloat(accel_msg->mean_x_accel),
-      halfToFloat(accel_msg->max_x_accel));
-  LOG("....Y min/mean/max: %0.4f / %0.4f / %0.4f",
-      halfToFloat(accel_msg->min_y_accel), halfToFloat(accel_msg->mean_y_accel),
-      halfToFloat(accel_msg->max_y_accel));
-  LOG("....Z min/mean/max: %0.4f / %0.4f / %0.4f",
-      halfToFloat(accel_msg->min_z_accel), halfToFloat(accel_msg->mean_z_accel),
-      halfToFloat(accel_msg->max_z_accel));
-  LOG("Lat = %0.2f, Lon = %0.2f", accel_msg->latitude, accel_msg->longitude);
+  // LOG("....time.: %ul", accel_msg->timestamp);
+  // LOG("....X min/mean/max: %0.4f / %0.4f / %0.4f",
+  //     halfToFloat(accel_msg->min_x_accel),
+  //     halfToFloat(accel_msg->mean_x_accel),
+  //     halfToFloat(accel_msg->max_x_accel));
+  // LOG("....Y min/mean/max: %0.4f / %0.4f / %0.4f",
+  //     halfToFloat(accel_msg->min_y_accel),
+  //     halfToFloat(accel_msg->mean_y_accel),
+  //     halfToFloat(accel_msg->max_y_accel));
+  // LOG("....Z min/mean/max: %0.4f / %0.4f / %0.4f",
+  //     halfToFloat(accel_msg->min_z_accel),
+  //     halfToFloat(accel_msg->mean_z_accel),
+  //     halfToFloat(accel_msg->max_z_accel));
+  // LOG("Lat = %0.2f, Lon = %0.2f", accel_msg->latitude, accel_msg->longitude);
 
   persistent_ram_save_message(ACCELEROMETER_TELEMETRY, priority,
                               (uint8_t *)accel_msg);

--- a/Core/Src/app_threadx.c
+++ b/Core/Src/app_threadx.c
@@ -1672,7 +1672,9 @@ static void light_thread_entry(ULONG thread_input) {
   light.off();
 
   light.assemble_telemetry_message_element(&sbd_msg_element);
-  persistent_ram_save_message(LIGHT_TELEMETRY, (uint8_t *)&sbd_msg_element);
+  float light_msg_priority = 1;
+  persistent_ram_save_message(LIGHT_TELEMETRY, light_msg_priority,
+                              (uint8_t *)&sbd_msg_element);
 
   watchdog_check_in(LIGHT_THREAD);
 
@@ -1786,7 +1788,9 @@ static void turbidity_thread_entry(ULONG thread_input) {
   obs.off();
 
   obs.assemble_telemetry_message_element(&sbd_msg_element);
-  persistent_ram_save_message(TURBIDITY_TELEMETRY, (uint8_t *)&sbd_msg_element);
+  float obs_msg_priority = 1;
+  persistent_ram_save_message(TURBIDITY_TELEMETRY, obs_msg_priority,
+                              (uint8_t *)&sbd_msg_element);
 
   watchdog_check_in(TURBIDITY_THREAD);
 
@@ -2014,7 +2018,10 @@ static void iridium_thread_entry(ULONG thread_input) {
     // Need to save the message
     error_bits = get_current_flags(&error_flags);
     error_bits |= IRIDIUM_INIT_ERROR;
-    persistent_ram_save_message(WAVES_TELEMETRY, (uint8_t *)&sbd_message);
+    float waves_msg_priority =
+        fabsf(halfToFloat(((sbd_message_type_52 *)msg_ptr)->Hs));
+    persistent_ram_save_message(WAVES_TELEMETRY, waves_msg_priority,
+                                (uint8_t *)&sbd_message);
     iridium_error_out(&iridium, IRIDIUM_UART_COMMS_ERROR, this_thread,
                       "Iridium modem UART communication error.");
   }
@@ -2119,7 +2126,9 @@ static void iridium_thread_entry(ULONG thread_input) {
     error_bits = control_get_accumulated_error_flags();
     memcpy(&sbd_message.error_bits, &error_bits, sizeof(uint32_t));
     // Save the message
-    persistent_ram_save_message(WAVES_TELEMETRY, msg_ptr);
+    float waves_msg_priority =
+        fabsf(halfToFloat(((sbd_message_type_52 *)msg_ptr)->Hs));
+    persistent_ram_save_message(WAVES_TELEMETRY, waves_msg_priority, msg_ptr);
 
     tx_thread_sleep(10);
   }
@@ -2264,7 +2273,10 @@ static void accel_thread_entry(ULONG thread_input) {
       halfToFloat(accel_msg.max_z_accel));
   LOG("Lat = %0.2f, Lon = %0.2f", accel_msg.latitude, accel_msg.longitude);
 
-  persistent_ram_save_message(ACCELEROMETER_TELEMETRY, (uint8_t *)&accel_msg);
+  // TODO: Replace this with the sum-of-spectra that Jim requested
+  float accel_msg_priority = fabsf(halfToFloat(accel_msg.max_z_accel));
+  persistent_ram_save_message(ACCELEROMETER_TELEMETRY, accel_msg_priority,
+                              (uint8_t *)&accel_msg);
 
   // TODO: Add saving the data. I'm not yet sure whether we need a whole
   //       struct to hold the accelerometer-related variables ...

--- a/Core/Src/app_threadx.c
+++ b/Core/Src/app_threadx.c
@@ -684,8 +684,6 @@ UINT App_ThreadX_Init(VOID *memory_ptr)
   device_handles.expansion_uart_rx_dma_handle = &handle_GPDMA1_Channel2;
 
   persistent_ram_get_device_config(&configuration);
-  // TODO: Revert this once I've added it to the configuration!
-  // configuration.accelerometer_enabled = true;
 
   // clang-format off
   /* USER CODE END App_ThreadX_MEM_POOL */
@@ -2159,8 +2157,12 @@ static void accel_thread_entry(ULONG thread_input) {
   // https://github.com/SASlabgroup/microSWIFT_V2.2_Firmware/issues/1
   // LOG("accel_thread_entry");
   // Calling it after a sleep is fine
-  // tx_thread_sleep(100);
-  // LOG("accel_thread_entry");
+  tx_thread_sleep(100);
+  if (configuration.accelerometer_continuous_sampling) {
+    LOG("accel_thread_entry: running in continuous mode");
+  } else {
+    LOG("accel_thread_entry: running in polled mode");
+  }
 
   Accelerometer accel = {0};
   accelerometer_init(&accel, device_handles.expansion_uart_handle,

--- a/Core/Src/app_threadx.c
+++ b/Core/Src/app_threadx.c
@@ -2185,13 +2185,6 @@ static void accel_thread_entry(ULONG thread_input) {
     (void)tx_event_flags_set(&initialization_flags, ACCELEROMETER_INIT_SUCCESS,
                              TX_OR);
   }
-  // We can't set the time until GNSS time has initialized.
-  // TODO: Once I finish testing the implementation, move this to the
-  //   start of the sampling window and uncomment get_system_time()
-  // uint32_t timestamp = (uint32_t)get_system_time();
-  uint32_t timestamp = 1777829511;
-  accel.set_time(timestamp);
-  LOG("Attempted to set time to %lu", timestamp);
 
   tx_thread_sleep(10 * TX_TIMER_TICKS_PER_SECOND);
 
@@ -2211,12 +2204,17 @@ static void accel_thread_entry(ULONG thread_input) {
                     "Accel UART port failed to initialize");
   }
 
-  // TODO: Initialize time on accel board / confirm UART comms
-
   tx_thread_sleep(TX_TIMER_TICKS_PER_SECOND); // Time for board to wake back up.
 
+  // We can't set the time until GNSS time has initialized, so this needs
+  // to be after resuming the thread.
   // This timestamp is used for filling in fields of the SBD55 messages
-  timestamp = (uint32_t)get_system_time();
+  uint32_t timestamp = (uint32_t)get_system_time();
+  accel.set_time(timestamp);
+  LOG("Attempted to set accelerometer time to %lu (system time)", timestamp);
+
+  // If we send a second UART command immediately, it won't be received.
+  tx_thread_sleep(TX_TIMER_TICKS_PER_SECOND);
   accel.start_sampling();
 
   LOG("Accelerometer sample window started.");
@@ -2250,11 +2248,11 @@ static void accel_thread_entry(ULONG thread_input) {
 
   memcpy(&accel_msg.legacy_number_7, &ascii_7, sizeof(uint8_t));
   memcpy(&accel_msg.type, &accel_type, sizeof(uint8_t));
-  memcpy(&accel_msg.timestamp, &timestamp, sizeof(uint32_t));
   memcpy(&accel_msg.latitude, &msg_lat, sizeof(float));
   memcpy(&accel_msg.longitude, &msg_lon, sizeof(float));
 
   LOG("Received accelerometer message:");
+  LOG("....time.: %ul", accel_msg.timestamp);
   LOG("....X min/mean/max: %0.4f / %0.4f / %0.4f",
       halfToFloat(accel_msg.min_x_accel), halfToFloat(accel_msg.mean_x_accel),
       halfToFloat(accel_msg.max_x_accel));

--- a/Core/Src/controller.c
+++ b/Core/Src/controller.c
@@ -454,6 +454,26 @@ static void _control_manage_state(void) {
   (void)tx_event_flags_get(controller_self->complete_flags, ALL_EVENT_FLAGS,
                            TX_OR_CLEAR, &current_flags, TX_NO_WAIT);
 
+  // If we're running in continuous mode AND GNSS errored out,
+  // we may need to wake up the accelerometer thread once more in order
+  // to query the accel board for spectra.
+  if (controller_self->thread_status.gnss_complete &&
+      !controller_self->thread_status.accelerometer_complete) {
+
+    UINT thread_state;
+    UINT status =
+        tx_thread_info_get(controller_self->thread_handles->accel_thread, NULL,
+                           &thread_state, NULL, NULL, NULL, NULL, NULL, NULL);
+
+    if (status == TX_SUCCESS) {
+      // Thread information successfully retrieved
+      if (TX_SUSPENDED == thread_state) {
+        LOG("...accel thread_state was TX_SUSPENDED; resuming");
+        tx_thread_resume(controller_self->thread_handles->accel_thread);
+      }
+    }
+  }
+
   // Exit early case
   if (current_flags == 0) {
     return;
@@ -540,6 +560,14 @@ static void _control_manage_state(void) {
       ret |=
           tx_thread_resume(controller_self->thread_handles->temperature_thread);
     }
+    // If we're running the accelerometer in continuous mode, need to
+    // wake that thread back up so it can query the accel board for the
+    // highest priority messages.
+    if (controller_self->global_config->accelerometer_continuous_sampling &&
+        !controller_self->thread_status.accelerometer_complete) {
+      LOG("GNSS two minutes from completion: resuming accel_thread");
+      ret |= tx_thread_resume(controller_self->thread_handles->accel_thread);
+    }
   }
 
   // When the GNSS thread is complete, we can run the Waves algo
@@ -570,6 +598,9 @@ static void _control_manage_state(void) {
     // operationally, should we also start the light thread so we get
     // that data as well? (I guess normally you wouldn't because it's not worth
     // using 18 mins of battery just for light data?)
+    //
+    // NB: This works for polled mode, but the continuous mode needs an
+    //     additional resume to request data after sampling.
     if (!controller_self->thread_status.accelerometer_complete) {
       LOG("No GNSS fix; resuming accelerometer thread anyways");
       ret |= tx_thread_resume(controller_self->thread_handles->accel_thread);

--- a/Core/Src/controller.c
+++ b/Core/Src/controller.c
@@ -735,8 +735,10 @@ static void _control_monitor_and_handle_errors(void) {
 }
 
 static void __get_alarm_settings(rtc_alarm_struct *alarm) {
-  struct tm boot_time = {0}, time_now = {0};
-  time_t boot_timestamp = 0, now_timestamp = 0;
+  struct tm boot_time = {0};
+  struct tm time_now = {0};
+  time_t boot_timestamp = 0;
+  time_t now_timestamp = 0;
 
   alarm->day_alarm_en = false;
   alarm->hour_alarm_en = true;

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -61,7 +61,7 @@
 // clang-format on
 
 #define HARDWARE_VERSION (2U)
-#define FIRMWARE_VERSION (9U)
+#define FIRMWARE_VERSION (10U)
 
 static const microSWIFT_firmware_version_t firmware_version = {
     HARDWARE_VERSION, FIRMWARE_VERSION};

--- a/Core/Src/persistent_ram.c
+++ b/Core/Src/persistent_ram.c
@@ -245,7 +245,9 @@ uint32_t persistent_ram_get_num_msgs_enqueued(telemetry_type_t msg_type) {
  *
  * @return void
  */
-void persistent_ram_save_message(telemetry_type_t msg_type, uint8_t *msg) {
+
+void persistent_ram_save_message(telemetry_type_t msg_type, float msg_priority,
+                                 uint8_t *msg) {
   int i = 0;
 
   // Corruption, lack of initialization check

--- a/Core/Src/persistent_ram.c
+++ b/Core/Src/persistent_ram.c
@@ -5,45 +5,45 @@
  *      Author: philbush
  */
 
-#include <ext_rtc_server.h>
 #include "persistent_ram.h"
 #include "float.h"
 #include "logger.h"
 #include "math.h"
 #include "string.h"
 #include "time.h"
+#include <ext_rtc_server.h>
 
-// Save the struct in SRAM2 -- NOLOAD section which will be retained in standby mode
+// Save the struct in SRAM2 -- NOLOAD section which will be retained in standby
+// mode
 static Persistent_Storage persistent_self __attribute__((section(".sram2")));
 
 // Helper functions
-static void _persistent_ram_clear ( void );
+static void _persistent_ram_clear(void);
 
 /**
- * Initialize the persistent memory (SRAM 2). This memory section can be maintained during Standby mode.
+ * Initialize the persistent memory (SRAM 2). This memory section can be
+ * maintained during Standby mode.
  *
  * @return void
  */
-void persistent_ram_init ( const microSWIFT_configuration *config,
-                           const microSWIFT_firmware_version_t *version )
-{
-  uint32_t reset_reason = HAL_RCC_GetResetSource ();
+void persistent_ram_init(const microSWIFT_configuration *config,
+                         const microSWIFT_firmware_version_t *version) {
+  uint32_t reset_reason = HAL_RCC_GetResetSource();
 
   // If this has not been initialized previously
-  if ( persistent_self.magic_number != PERSISTENT_RAM_MAGIC_DOUBLE_WORD )
-  {
-    _persistent_ram_clear ();
-    persistent_ram_set_device_config (config, false);
-    persistent_ram_set_firmware_version (version);
+  if (persistent_self.magic_number != PERSISTENT_RAM_MAGIC_DOUBLE_WORD) {
+    _persistent_ram_clear();
+    persistent_ram_set_device_config(config, false);
+    persistent_ram_set_firmware_version(version);
 
     persistent_self.magic_number = PERSISTENT_RAM_MAGIC_DOUBLE_WORD;
   }
-  // If a watchdog reset occurred (identified as a hardware pin reset), clear everything out
-  else if ( reset_reason == RCC_RESET_FLAG_PIN )
-  {
-    _persistent_ram_clear ();
-    persistent_ram_set_device_config (config, false);
-    persistent_ram_set_firmware_version (version);
+  // If a watchdog reset occurred (identified as a hardware pin reset), clear
+  // everything out
+  else if (reset_reason == RCC_RESET_FLAG_PIN) {
+    _persistent_ram_clear();
+    persistent_ram_set_device_config(config, false);
+    persistent_ram_set_firmware_version(version);
 
     persistent_self.magic_number = PERSISTENT_RAM_MAGIC_DOUBLE_WORD;
   }
@@ -51,13 +51,11 @@ void persistent_ram_init ( const microSWIFT_configuration *config,
   persistent_self.reset_reason = reset_reason;
 
   // If the RTC has not been set, then reset the sample window counter
-  if ( !persistent_ram_get_rtc_time_set () )
-  {
+  if (!persistent_ram_get_rtc_time_set()) {
     persistent_self.sample_window_counter = 1;
   }
   // Otherwise increment it
-  else
-  {
+  else {
     persistent_self.sample_window_counter++;
   }
 }
@@ -67,10 +65,9 @@ void persistent_ram_init ( const microSWIFT_configuration *config,
  *
  * @return void
  */
-void persistent_ram_deinit ( void )
-{
+void persistent_ram_deinit(void) {
   // Clear everything out
-  _persistent_ram_clear ();
+  _persistent_ram_clear();
 }
 
 /**
@@ -78,9 +75,10 @@ void persistent_ram_deinit ( void )
  *
  * @return void
  */
-void persistent_ram_set_device_config ( const microSWIFT_configuration *config, bool ota_update )
-{
-  memcpy (&persistent_self.device_config, config, sizeof(microSWIFT_configuration));
+void persistent_ram_set_device_config(const microSWIFT_configuration *config,
+                                      bool ota_update) {
+  memcpy(&persistent_self.device_config, config,
+         sizeof(microSWIFT_configuration));
 
   persistent_self.ota_update_received = ota_update;
 }
@@ -90,9 +88,9 @@ void persistent_ram_set_device_config ( const microSWIFT_configuration *config, 
  *
  * @return void
  */
-void persistent_ram_get_device_config ( microSWIFT_configuration *config )
-{
-  memcpy (config, &persistent_self.device_config, sizeof(microSWIFT_configuration));
+void persistent_ram_get_device_config(microSWIFT_configuration *config) {
+  memcpy(config, &persistent_self.device_config,
+         sizeof(microSWIFT_configuration));
 }
 
 /**
@@ -100,9 +98,10 @@ void persistent_ram_get_device_config ( microSWIFT_configuration *config )
  *
  * @return void
  */
-void persistent_ram_set_firmware_version ( const microSWIFT_firmware_version_t *version )
-{
-  memcpy (&persistent_self.version, version, sizeof(microSWIFT_firmware_version_t));
+void persistent_ram_set_firmware_version(
+    const microSWIFT_firmware_version_t *version) {
+  memcpy(&persistent_self.version, version,
+         sizeof(microSWIFT_firmware_version_t));
 }
 
 /**
@@ -110,9 +109,10 @@ void persistent_ram_set_firmware_version ( const microSWIFT_firmware_version_t *
  *
  * @return void
  */
-void persistent_ram_get_firmware_version ( microSWIFT_firmware_version_t *version )
-{
-  memcpy (version, &persistent_self.version, sizeof(microSWIFT_firmware_version_t));
+void persistent_ram_get_firmware_version(
+    microSWIFT_firmware_version_t *version) {
+  memcpy(version, &persistent_self.version,
+         sizeof(microSWIFT_firmware_version_t));
 }
 
 /**
@@ -120,8 +120,7 @@ void persistent_ram_get_firmware_version ( microSWIFT_firmware_version_t *versio
  *
  * @return void
  */
-bool persistent_ram_get_ota_update_status ( void )
-{
+bool persistent_ram_get_ota_update_status(void) {
   return persistent_self.ota_update_received;
 }
 
@@ -130,8 +129,7 @@ bool persistent_ram_get_ota_update_status ( void )
  *
  * @return void
  */
-bool persistent_ram_get_ota_ack_status ( void )
-{
+bool persistent_ram_get_ota_ack_status(void) {
   return persistent_self.ota_acknowledgement_sent;
 }
 
@@ -140,19 +138,20 @@ bool persistent_ram_get_ota_ack_status ( void )
  *
  * @return void
  */
-void persistent_ram_set_ota_ack_msg ( sbd_message_type_99 *msg )
-{
-  memcpy (&persistent_self.ota_acknowledgement_msg, msg, sizeof(sbd_message_type_99));
+void persistent_ram_set_ota_ack_msg(sbd_message_type_99 *msg) {
+  memcpy(&persistent_self.ota_acknowledgement_msg, msg,
+         sizeof(sbd_message_type_99));
 }
 
 /**
- * Copy the OTA ack message to the provided return pointer if Tx was unsuccessful.
+ * Copy the OTA ack message to the provided return pointer if Tx was
+ * unsuccessful.
  *
  * @return void
  */
-void persistent_ram_get_ota_ack_msg ( sbd_message_type_99 *msg )
-{
-  memcpy (msg, &persistent_self.ota_acknowledgement_msg, sizeof(sbd_message_type_99));
+void persistent_ram_get_ota_ack_msg(sbd_message_type_99 *msg) {
+  memcpy(msg, &persistent_self.ota_acknowledgement_msg,
+         sizeof(sbd_message_type_99));
 }
 
 /**
@@ -160,8 +159,7 @@ void persistent_ram_get_ota_ack_msg ( sbd_message_type_99 *msg )
  *
  * @return sample_window_counter
  */
-uint32_t persistent_ram_get_sample_window_counter ( void )
-{
+uint32_t persistent_ram_get_sample_window_counter(void) {
   return persistent_self.sample_window_counter;
 }
 
@@ -170,8 +168,7 @@ uint32_t persistent_ram_get_sample_window_counter ( void )
  *
  * @return void
  */
-void persistent_ram_reset_sample_window_counter ( void )
-{
+void persistent_ram_reset_sample_window_counter(void) {
   persistent_self.sample_window_counter = 0;
 }
 
@@ -180,8 +177,7 @@ void persistent_ram_reset_sample_window_counter ( void )
  *
  * @return void
  */
-void persistent_ram_set_rtc_time_set ( void )
-{
+void persistent_ram_set_rtc_time_set(void) {
   persistent_self.rtc_time_set = true;
 }
 
@@ -190,18 +186,17 @@ void persistent_ram_set_rtc_time_set ( void )
  *
  * @return rtc_time_set flag
  */
-bool persistent_ram_get_rtc_time_set ( void )
-{
+bool persistent_ram_get_rtc_time_set(void) {
   return persistent_self.rtc_time_set;
 }
 
 /**
- * Get the reset reason code, defined in @defgroup RCC_Reset_Flag Reset Flag within stm32u5xx_hal_rcc.h.
+ * Get the reset reason code, defined in @defgroup RCC_Reset_Flag Reset Flag
+ * within stm32u5xx_hal_rcc.h.
  *
  * @return rtc_time_set flag
  */
-uint32_t persistent_ram_get_reset_reason ( void )
-{
+uint32_t persistent_ram_get_reset_reason(void) {
   return persistent_self.reset_reason;
 }
 
@@ -210,502 +205,481 @@ uint32_t persistent_ram_get_reset_reason ( void )
  *
  * @return void
  */
-uint32_t persistent_ram_get_num_msgs_enqueued ( telemetry_type_t msg_type )
-{
-  switch ( msg_type )
-  {
-    case WAVES_TELEMETRY:
-      LOG("Number of enqueued Waves messages: %lu",
-          persistent_self.waves_storage.num_telemetry_msgs_enqueued);
-      return persistent_self.waves_storage.num_telemetry_msgs_enqueued;
-      break;
+uint32_t persistent_ram_get_num_msgs_enqueued(telemetry_type_t msg_type) {
+  switch (msg_type) {
+  case WAVES_TELEMETRY:
+    LOG("Number of enqueued Waves messages: %lu",
+        persistent_self.waves_storage.num_telemetry_msgs_enqueued);
+    return persistent_self.waves_storage.num_telemetry_msgs_enqueued;
+    break;
 
-    case TURBIDITY_TELEMETRY:
-      LOG("Number of enqueued OBS message elements: %lu",
-          persistent_self.turbidity_storage.num_msg_elements_enqueued);
-      return persistent_self.turbidity_storage.num_msg_elements_enqueued / TURBIDITY_MSGS_PER_SBD;
-      break;
+  case TURBIDITY_TELEMETRY:
+    LOG("Number of enqueued OBS message elements: %lu",
+        persistent_self.turbidity_storage.num_msg_elements_enqueued);
+    return persistent_self.turbidity_storage.num_msg_elements_enqueued /
+           TURBIDITY_MSGS_PER_SBD;
+    break;
 
-    case LIGHT_TELEMETRY:
-      LOG("Number of enqueued Light message elements: %lu",
-          persistent_self.light_storage.num_msg_elements_enqueued);
-      return persistent_self.light_storage.num_msg_elements_enqueued / LIGHT_MSGS_PER_SBD;
-      break;
+  case LIGHT_TELEMETRY:
+    LOG("Number of enqueued Light message elements: %lu",
+        persistent_self.light_storage.num_msg_elements_enqueued);
+    return persistent_self.light_storage.num_msg_elements_enqueued /
+           LIGHT_MSGS_PER_SBD;
+    break;
 
-    case ACCELEROMETER_TELEMETRY:
-      LOG("Number of enqueued Accelerometer messages: %lu",
-          persistent_self.accelerometer_storage.num_telemetry_msgs_enqueued);
-      return persistent_self.accelerometer_storage.num_telemetry_msgs_enqueued;
-      break;
+  case ACCELEROMETER_TELEMETRY:
+    LOG("Number of enqueued Accelerometer messages: %lu",
+        persistent_self.accelerometer_storage.num_telemetry_msgs_enqueued);
+    return persistent_self.accelerometer_storage.num_telemetry_msgs_enqueued;
+    break;
 
-    default:
-      return 0;
+  default:
+    return 0;
   }
 }
 
 /**
  * Save an SBD message for later transmission.
- * !! Turbidity and Light messages are saved as single elements, not a full SBD message.
+ * !! Turbidity and Light messages are saved as single elements, not a full SBD
+ * message.
  *
  * @return void
  */
-void persistent_ram_save_message ( telemetry_type_t msg_type, uint8_t *msg )
-{
+void persistent_ram_save_message(telemetry_type_t msg_type, uint8_t *msg) {
   int i = 0;
 
   // Corruption, lack of initialization check
-  if ( persistent_self.magic_number != PERSISTENT_RAM_MAGIC_DOUBLE_WORD )
-  {
-    _persistent_ram_clear ();
+  if (persistent_self.magic_number != PERSISTENT_RAM_MAGIC_DOUBLE_WORD) {
+    _persistent_ram_clear();
   }
 
-  switch ( msg_type )
-  {
-    case WAVES_TELEMETRY:
-      // If the storage queue is full, see if we can replace an element
-      if ( persistent_self.waves_storage.num_telemetry_msgs_enqueued == MAX_NUM_WAVES_MSGS_STORED )
-      {
-        for ( i = 0; i < MAX_NUM_WAVES_MSGS_STORED; i++ )
-        {
-          // Want to make sure we are comparing absolute values, though wave height should always be positive
-          if ( (fabsf (halfToFloat (persistent_self.waves_storage.msg_queue[i].payload.Hs)))
-               < fabsf (halfToFloat (((sbd_message_type_52*) msg)->Hs)) )
-          {
-            // copy the message over
-            memcpy (&(persistent_self.waves_storage.msg_queue[i].payload), msg,
-                    sizeof(sbd_message_type_52));
-            // Make the entry valid (should already be, but just in case)
-            persistent_self.waves_storage.msg_queue[i].valid = true;
-            return;
-          }
+  switch (msg_type) {
+  case WAVES_TELEMETRY:
+    // If the storage queue is full, see if we can replace an element
+    if (persistent_self.waves_storage.num_telemetry_msgs_enqueued ==
+        MAX_NUM_WAVES_MSGS_STORED) {
+      for (i = 0; i < MAX_NUM_WAVES_MSGS_STORED; i++) {
+        // Want to make sure we are comparing absolute values, though wave
+        // height should always be positive
+        if ((fabsf(halfToFloat(
+                persistent_self.waves_storage.msg_queue[i].payload.Hs))) <
+            fabsf(halfToFloat(((sbd_message_type_52 *)msg)->Hs))) {
+          // copy the message over
+          memcpy(&(persistent_self.waves_storage.msg_queue[i].payload), msg,
+                 sizeof(sbd_message_type_52));
+          // Make the entry valid (should already be, but just in case)
+          persistent_self.waves_storage.msg_queue[i].valid = true;
+          return;
         }
       }
-      else
-      {
-        // Not full, just need to find an open slot
-        for ( i = 0; i < MAX_NUM_WAVES_MSGS_STORED; i++ )
-        {
-          if ( !persistent_self.waves_storage.msg_queue[i].valid )
-          {
-            // copy the message over
-            memcpy (&(persistent_self.waves_storage.msg_queue[i].payload), msg,
-                    sizeof(sbd_message_type_52));
-            // Make the entry valid
-            persistent_self.waves_storage.msg_queue[i].valid = true;
-            persistent_self.waves_storage.num_telemetry_msgs_enqueued++;
-            return;
-          }
+    } else {
+      // Not full, just need to find an open slot
+      for (i = 0; i < MAX_NUM_WAVES_MSGS_STORED; i++) {
+        if (!persistent_self.waves_storage.msg_queue[i].valid) {
+          // copy the message over
+          memcpy(&(persistent_self.waves_storage.msg_queue[i].payload), msg,
+                 sizeof(sbd_message_type_52));
+          // Make the entry valid
+          persistent_self.waves_storage.msg_queue[i].valid = true;
+          persistent_self.waves_storage.num_telemetry_msgs_enqueued++;
+          return;
         }
       }
+    }
 
-      break;
+    break;
 
-    case ACCELEROMETER_TELEMETRY:
-      // If the storage queue is full, see if we can replace an element
-      if ( persistent_self.accelerometer_storage.num_telemetry_msgs_enqueued == MAX_NUM_ACCELEROMETER_MSGS_STORED )
-      {
-        for ( i = 0; i < MAX_NUM_ACCELEROMETER_MSGS_STORED; i++ )
-        {
-          // TODO: Ask Jim what metric to use here since we do not calculate
-          //       wave heights for accelerometer data.
-          // NOTE: The previous logic simply replaces the first message with
-          //       smaller wave heights; instead, it might make sense to
-          //       replace the absolute smallest element.
-          if ( (fabsf (halfToFloat (persistent_self.accelerometer_storage.msg_queue[i].payload.max_z_accel)))
-               < fabsf (halfToFloat (((sbd_message_type_55*) msg)->max_z_accel)) )
-          {
-            // copy the message over
-            memcpy (&(persistent_self.accelerometer_storage.msg_queue[i].payload), msg,
-                    sizeof(sbd_message_type_55));
-            // Make the entry valid (should already be, but just in case)
-            persistent_self.accelerometer_storage.msg_queue[i].valid = true;
-            return;
-          }
+  case ACCELEROMETER_TELEMETRY:
+    // If the storage queue is full, see if we can replace an element
+    if (persistent_self.accelerometer_storage.num_telemetry_msgs_enqueued ==
+        MAX_NUM_ACCELEROMETER_MSGS_STORED) {
+      for (i = 0; i < MAX_NUM_ACCELEROMETER_MSGS_STORED; i++) {
+        // TODO: Ask Jim what metric to use here since we do not calculate
+        //       wave heights for accelerometer data.
+        // NOTE: The previous logic simply replaces the first message with
+        //       smaller wave heights; instead, it might make sense to
+        //       replace the absolute smallest element.
+        if ((fabsf(
+                halfToFloat(persistent_self.accelerometer_storage.msg_queue[i]
+                                .payload.max_z_accel))) <
+            fabsf(halfToFloat(((sbd_message_type_55 *)msg)->max_z_accel))) {
+          // copy the message over
+          memcpy(&(persistent_self.accelerometer_storage.msg_queue[i].payload),
+                 msg, sizeof(sbd_message_type_55));
+          // Make the entry valid (should already be, but just in case)
+          persistent_self.accelerometer_storage.msg_queue[i].valid = true;
+          return;
         }
-        // Do we want to log that we're discarding a message due to full queue?
       }
-      else
-      {
-        // Not full, just need to find an open slot
-        for ( i = 0; i < MAX_NUM_ACCELEROMETER_MSGS_STORED; i++ )
-        {
-          if ( !persistent_self.accelerometer_storage.msg_queue[i].valid )
-          {
-            // copy the message over
-            memcpy (&(persistent_self.accelerometer_storage.msg_queue[i].payload), msg,
-                    sizeof(sbd_message_type_55));
-            // Make the entry valid
-            persistent_self.accelerometer_storage.msg_queue[i].valid = true;
-            persistent_self.accelerometer_storage.num_telemetry_msgs_enqueued++;
-            return;
-          }
+      // Do we want to log that we're discarding a message due to full queue?
+    } else {
+      // Not full, just need to find an open slot
+      for (i = 0; i < MAX_NUM_ACCELEROMETER_MSGS_STORED; i++) {
+        if (!persistent_self.accelerometer_storage.msg_queue[i].valid) {
+          // copy the message over
+          memcpy(&(persistent_self.accelerometer_storage.msg_queue[i].payload),
+                 msg, sizeof(sbd_message_type_55));
+          // Make the entry valid
+          persistent_self.accelerometer_storage.msg_queue[i].valid = true;
+          persistent_self.accelerometer_storage.num_telemetry_msgs_enqueued++;
+          return;
         }
-        // Getting here would indicate an error -- should we log that?
       }
+      // Getting here would indicate an error -- should we log that?
+    }
 
-      break;
+    break;
 
-    case TURBIDITY_TELEMETRY:
-      // If the storage queue is full, then just skip
-      if ( !(persistent_self.turbidity_storage.num_msg_elements_enqueued
-             == MAX_NUM_TURBIDITY_MSGS_STORED) )
-      {
-        // First check if there is room in the current message index
-        for ( i = 0; i < TURBIDITY_MSGS_PER_SBD; i++ )
-        {
-          if ( !persistent_self.turbidity_storage.msg_queue[persistent_self.turbidity_storage
-              .current_msg_index].valid[i] )
-          {
-            // copy the message over
-            memcpy (
-                &(persistent_self.turbidity_storage.msg_queue[persistent_self.turbidity_storage
-                    .current_msg_index].payload.elements[i]),
-                msg, sizeof(sbd_message_type_53_element));
-            // Make the entry valid
-            persistent_self.turbidity_storage.msg_queue[persistent_self.turbidity_storage
-                .current_msg_index].valid[i] = true;
-            persistent_self.turbidity_storage.num_msg_elements_enqueued++;
-            return;
-          }
-        }
-
-        // Need to start a new message
-        for ( i = 0; i < MAX_NUM_NON_WAVES_MSGS_STORED; i++ )
-        {
-          if ( !persistent_self.turbidity_storage.msg_queue[i].valid[0] )
-          {
-            // copy the message over
-            memcpy (&(persistent_self.turbidity_storage.msg_queue[i].payload.elements[0]), msg,
-                    sizeof(sbd_message_type_53_element));
-            // Make the entry valid
-            persistent_self.turbidity_storage.msg_queue[i].valid[0] = true;
-            persistent_self.turbidity_storage.num_msg_elements_enqueued++;
-            persistent_self.turbidity_storage.current_msg_index = i;
-            return;
-          }
+  case TURBIDITY_TELEMETRY:
+    // If the storage queue is full, then just skip
+    if (!(persistent_self.turbidity_storage.num_msg_elements_enqueued ==
+          MAX_NUM_TURBIDITY_MSGS_STORED)) {
+      // First check if there is room in the current message index
+      for (i = 0; i < TURBIDITY_MSGS_PER_SBD; i++) {
+        if (!persistent_self.turbidity_storage
+                 .msg_queue[persistent_self.turbidity_storage.current_msg_index]
+                 .valid[i]) {
+          // copy the message over
+          memcpy(&(persistent_self.turbidity_storage
+                       .msg_queue[persistent_self.turbidity_storage
+                                      .current_msg_index]
+                       .payload.elements[i]),
+                 msg, sizeof(sbd_message_type_53_element));
+          // Make the entry valid
+          persistent_self.turbidity_storage
+              .msg_queue[persistent_self.turbidity_storage.current_msg_index]
+              .valid[i] = true;
+          persistent_self.turbidity_storage.num_msg_elements_enqueued++;
+          return;
         }
       }
 
-      break;
-
-    case LIGHT_TELEMETRY:
-      // If the storage queue is full, then just skip
-      if ( !(persistent_self.light_storage.num_msg_elements_enqueued == MAX_NUM_LIGHT_MSGS_STORED) )
-      {
-        // First check if there is room in the current message index
-        for ( i = 0; i < LIGHT_MSGS_PER_SBD; i++ )
-        {
-          if ( !persistent_self.light_storage.msg_queue[persistent_self.light_storage
-              .current_msg_index].valid[i] )
-          {
-            // copy the message over
-            memcpy (
-                &(persistent_self.light_storage.msg_queue[persistent_self.light_storage
-                    .current_msg_index].payload.elements[i]),
-                msg, sizeof(sbd_message_type_54_element));
-            // Make the entry valid
-            persistent_self.light_storage.msg_queue[persistent_self.light_storage.current_msg_index]
-                .valid[i] = true;
-            persistent_self.light_storage.num_msg_elements_enqueued++;
-            return;
-          }
+      // Need to start a new message
+      for (i = 0; i < MAX_NUM_NON_WAVES_MSGS_STORED; i++) {
+        if (!persistent_self.turbidity_storage.msg_queue[i].valid[0]) {
+          // copy the message over
+          memcpy(&(persistent_self.turbidity_storage.msg_queue[i]
+                       .payload.elements[0]),
+                 msg, sizeof(sbd_message_type_53_element));
+          // Make the entry valid
+          persistent_self.turbidity_storage.msg_queue[i].valid[0] = true;
+          persistent_self.turbidity_storage.num_msg_elements_enqueued++;
+          persistent_self.turbidity_storage.current_msg_index = i;
+          return;
         }
+      }
+    }
 
-        // Need to start a new message
-        for ( i = 0; i < MAX_NUM_NON_WAVES_MSGS_STORED; i++ )
-        {
-          if ( !persistent_self.light_storage.msg_queue[i].valid[0] )
-          {
-            // copy the message over
-            memcpy (&(persistent_self.light_storage.msg_queue[i].payload.elements[0]), msg,
-                    sizeof(sbd_message_type_54_element));
-            // Make the entry valid
-            persistent_self.light_storage.msg_queue[i].valid[0] = true;
-            persistent_self.light_storage.num_msg_elements_enqueued++;
-            persistent_self.light_storage.current_msg_index = i;
-            return;
-          }
+    break;
+
+  case LIGHT_TELEMETRY:
+    // If the storage queue is full, then just skip
+    if (!(persistent_self.light_storage.num_msg_elements_enqueued ==
+          MAX_NUM_LIGHT_MSGS_STORED)) {
+      // First check if there is room in the current message index
+      for (i = 0; i < LIGHT_MSGS_PER_SBD; i++) {
+        if (!persistent_self.light_storage
+                 .msg_queue[persistent_self.light_storage.current_msg_index]
+                 .valid[i]) {
+          // copy the message over
+          memcpy(
+              &(persistent_self.light_storage
+                    .msg_queue[persistent_self.light_storage.current_msg_index]
+                    .payload.elements[i]),
+              msg, sizeof(sbd_message_type_54_element));
+          // Make the entry valid
+          persistent_self.light_storage
+              .msg_queue[persistent_self.light_storage.current_msg_index]
+              .valid[i] = true;
+          persistent_self.light_storage.num_msg_elements_enqueued++;
+          return;
         }
       }
 
-      break;
+      // Need to start a new message
+      for (i = 0; i < MAX_NUM_NON_WAVES_MSGS_STORED; i++) {
+        if (!persistent_self.light_storage.msg_queue[i].valid[0]) {
+          // copy the message over
+          memcpy(
+              &(persistent_self.light_storage.msg_queue[i].payload.elements[0]),
+              msg, sizeof(sbd_message_type_54_element));
+          // Make the entry valid
+          persistent_self.light_storage.msg_queue[i].valid[0] = true;
+          persistent_self.light_storage.num_msg_elements_enqueued++;
+          persistent_self.light_storage.current_msg_index = i;
+          return;
+        }
+      }
+    }
 
-    default:
-      return;
+    break;
+
+  default:
+    return;
   }
 }
 
 /**
- * Return a pointer to the highest priority message of a given type. If no message is
- * available, return pointer will be NULL.
- * !!@ This always returns a pointer to a FULL SBD MESSAGE, not just a single message element.
+ * Return a pointer to the highest priority message of a given type. If no
+ * message is available, return pointer will be NULL.
+ * !!@ This always returns a pointer to a FULL SBD MESSAGE, not just a single
+ * message element.
  *
  * @return void
  */
-uint8_t* persistent_ram_get_prioritized_unsent_message ( telemetry_type_t msg_type )
-{
-  // Set to float min value to ensure any message significant wave height will be greater than or equal to
+uint8_t *
+persistent_ram_get_prioritized_unsent_message(telemetry_type_t msg_type) {
+  // Set to float min value to ensure any message significant wave height will
+  // be greater than or equal to
   float most_significant_wave_height = -FLT_MAX;
   float msg_wave_height = 0.0;
-  real16_T msg_wave_half_float = { 0 };
+  real16_T msg_wave_half_float = {0};
   float max_z_accel = -FLT_MAX;
   float msg_z_accel = 0.0;
-  real16_T msg_accel_half_float = { 0 };
+  real16_T msg_accel_half_float = {0};
   int32_t pri_msg_index = 0, valid_msg_index = -1;
   bool msg_full = false;
   uint8_t *ret_ptr = NULL;
 
   // Corruption, lack of initialization check
-  if ( persistent_self.magic_number != PERSISTENT_RAM_MAGIC_DOUBLE_WORD )
-  {
-    _persistent_ram_clear ();
+  if (persistent_self.magic_number != PERSISTENT_RAM_MAGIC_DOUBLE_WORD) {
+    _persistent_ram_clear();
     return NULL;
   }
 
-  switch ( msg_type )
-  {
-    case WAVES_TELEMETRY:
+  switch (msg_type) {
+  case WAVES_TELEMETRY:
 
-      // Empty queue check
-      if ( persistent_self.waves_storage.num_telemetry_msgs_enqueued == 0 )
-      {
-        return NULL;
-      }
+    // Empty queue check
+    if (persistent_self.waves_storage.num_telemetry_msgs_enqueued == 0) {
+      return NULL;
+    }
 
-      // Find the largest significant wave height
-      for ( int i = 0; i < MAX_NUM_WAVES_MSGS_STORED; i++ )
-      {
-        if ( persistent_self.waves_storage.msg_queue[i].valid )
-        {
-          valid_msg_index = i;
-          msg_wave_half_float = persistent_self.waves_storage.msg_queue[i].payload.Hs;
-          msg_wave_height = fabsf (halfToFloat (msg_wave_half_float));
+    // Find the largest significant wave height
+    for (int i = 0; i < MAX_NUM_WAVES_MSGS_STORED; i++) {
+      if (persistent_self.waves_storage.msg_queue[i].valid) {
+        valid_msg_index = i;
+        msg_wave_half_float =
+            persistent_self.waves_storage.msg_queue[i].payload.Hs;
+        msg_wave_height = fabsf(halfToFloat(msg_wave_half_float));
 
-          if ( msg_wave_height >= most_significant_wave_height )
-          {
-            most_significant_wave_height = msg_wave_height;
-            pri_msg_index = i;
-          }
+        if (msg_wave_height >= most_significant_wave_height) {
+          most_significant_wave_height = msg_wave_height;
+          pri_msg_index = i;
         }
       }
+    }
 
-      // Make sure we don't go out of bounds. Take the priority message first, otherwise, any valid message
-      if ( (pri_msg_index >= 0) && (pri_msg_index <= (MAX_NUM_WAVES_MSGS_STORED - 1)) )
-      {
-        ret_ptr = (uint8_t*) &persistent_self.waves_storage.msg_queue[pri_msg_index].payload;
-      }
-      else if ( (valid_msg_index >= 0) && (valid_msg_index <= (MAX_NUM_WAVES_MSGS_STORED - 1)) )
-      {
-        ret_ptr = (uint8_t*) &persistent_self.waves_storage.msg_queue[valid_msg_index].payload;
-      }
-      else
-      {
-        ret_ptr = NULL;
-      }
-
-      break;
-
-    // This is a clone of the WAVES_TELEMETRY logic
-    case ACCELEROMETER_TELEMETRY:
-
-      // Empty queue check
-      if ( persistent_self.accelerometer_storage.num_telemetry_msgs_enqueued == 0 )
-      {
-        return NULL;
-      }
-
-      // Find the maximum acceleration in Z.
-      // TODO: Update this prioritization.
-      for ( int i = 0; i < MAX_NUM_ACCELEROMETER_MSGS_STORED; i++ )
-      {
-        if ( persistent_self.accelerometer_storage.msg_queue[i].valid )
-        {
-          valid_msg_index = i;
-          msg_accel_half_float = persistent_self.accelerometer_storage.msg_queue[i].payload.max_z_accel;
-          msg_z_accel = fabsf (halfToFloat (msg_accel_half_float));
-
-          if ( msg_z_accel >= max_z_accel )
-          {
-            max_z_accel = msg_z_accel;
-            pri_msg_index = i;
-          }
-        }
-      }
-
-      // Make sure we don't go out of bounds. Take the priority message first, otherwise, any valid message
-      if ( (pri_msg_index >= 0) && (pri_msg_index <= (MAX_NUM_ACCELEROMETER_MSGS_STORED - 1)) )
-      {
-        ret_ptr = (uint8_t*) &persistent_self.accelerometer_storage.msg_queue[pri_msg_index].payload;
-      }
-      else if ( (valid_msg_index >= 0) && (valid_msg_index <= (MAX_NUM_ACCELEROMETER_MSGS_STORED - 1)) )
-      {
-        ret_ptr = (uint8_t*) &persistent_self.accelerometer_storage.msg_queue[valid_msg_index].payload;
-      }
-      else
-      {
-        ret_ptr = NULL;
-      }
-
-      break;
-
-    case TURBIDITY_TELEMETRY:
-
-      // Make sure we have enough elements to constitute a full msg
-      if ( persistent_self.turbidity_storage.num_msg_elements_enqueued < TURBIDITY_MSGS_PER_SBD )
-      {
-        return NULL;
-      }
-
-      // Just take the first available
-      for ( int i = 0; i < MAX_NUM_NON_WAVES_MSGS_STORED; i++ )
-      {
-
-        msg_full = true;
-
-        for ( int j = 0; j < TURBIDITY_MSGS_PER_SBD; j++ )
-        {
-          if ( !persistent_self.turbidity_storage.msg_queue[i].valid[j] )
-          {
-            msg_full = false;
-            break;
-          }
-        }
-
-        if ( msg_full )
-        {
-          ret_ptr = (uint8_t*) &persistent_self.turbidity_storage.msg_queue[i].payload;
-          return ret_ptr;
-        }
-      }
-
-      break;
-
-    case LIGHT_TELEMETRY:
-
-      // Make sure we have enough elements to constitute a full msg
-      if ( persistent_self.light_storage.num_msg_elements_enqueued < LIGHT_MSGS_PER_SBD )
-      {
-        return NULL;
-      }
-
-      // Just take the first available
-      for ( int i = 0; i < MAX_NUM_NON_WAVES_MSGS_STORED; i++ )
-      {
-
-        msg_full = true;
-
-        for ( int j = 0; j < LIGHT_MSGS_PER_SBD; j++ )
-        {
-          if ( !persistent_self.light_storage.msg_queue[i].valid[j] )
-          {
-            msg_full = false;
-            break;
-          }
-        }
-
-        if ( msg_full )
-        {
-          ret_ptr = (uint8_t*) &persistent_self.light_storage.msg_queue[i].payload;
-          return ret_ptr;
-        }
-      }
-
-      break;
-
-    default:
+    // Make sure we don't go out of bounds. Take the priority message first,
+    // otherwise, any valid message
+    if ((pri_msg_index >= 0) &&
+        (pri_msg_index <= (MAX_NUM_WAVES_MSGS_STORED - 1))) {
+      ret_ptr =
+          (uint8_t *)&persistent_self.waves_storage.msg_queue[pri_msg_index]
+              .payload;
+    } else if ((valid_msg_index >= 0) &&
+               (valid_msg_index <= (MAX_NUM_WAVES_MSGS_STORED - 1))) {
+      ret_ptr =
+          (uint8_t *)&persistent_self.waves_storage.msg_queue[valid_msg_index]
+              .payload;
+    } else {
       ret_ptr = NULL;
+    }
+
+    break;
+
+  // This is a clone of the WAVES_TELEMETRY logic
+  case ACCELEROMETER_TELEMETRY:
+
+    // Empty queue check
+    if (persistent_self.accelerometer_storage.num_telemetry_msgs_enqueued ==
+        0) {
+      return NULL;
+    }
+
+    // Find the maximum acceleration in Z.
+    // TODO: Update this prioritization.
+    for (int i = 0; i < MAX_NUM_ACCELEROMETER_MSGS_STORED; i++) {
+      if (persistent_self.accelerometer_storage.msg_queue[i].valid) {
+        valid_msg_index = i;
+        msg_accel_half_float =
+            persistent_self.accelerometer_storage.msg_queue[i]
+                .payload.max_z_accel;
+        msg_z_accel = fabsf(halfToFloat(msg_accel_half_float));
+
+        if (msg_z_accel >= max_z_accel) {
+          max_z_accel = msg_z_accel;
+          pri_msg_index = i;
+        }
+      }
+    }
+
+    // Make sure we don't go out of bounds. Take the priority message first,
+    // otherwise, any valid message
+    if ((pri_msg_index >= 0) &&
+        (pri_msg_index <= (MAX_NUM_ACCELEROMETER_MSGS_STORED - 1))) {
+      ret_ptr = (uint8_t *)&persistent_self.accelerometer_storage
+                    .msg_queue[pri_msg_index]
+                    .payload;
+    } else if ((valid_msg_index >= 0) &&
+               (valid_msg_index <= (MAX_NUM_ACCELEROMETER_MSGS_STORED - 1))) {
+      ret_ptr = (uint8_t *)&persistent_self.accelerometer_storage
+                    .msg_queue[valid_msg_index]
+                    .payload;
+    } else {
+      ret_ptr = NULL;
+    }
+
+    break;
+
+  case TURBIDITY_TELEMETRY:
+
+    // Make sure we have enough elements to constitute a full msg
+    if (persistent_self.turbidity_storage.num_msg_elements_enqueued <
+        TURBIDITY_MSGS_PER_SBD) {
+      return NULL;
+    }
+
+    // Just take the first available
+    for (int i = 0; i < MAX_NUM_NON_WAVES_MSGS_STORED; i++) {
+
+      msg_full = true;
+
+      for (int j = 0; j < TURBIDITY_MSGS_PER_SBD; j++) {
+        if (!persistent_self.turbidity_storage.msg_queue[i].valid[j]) {
+          msg_full = false;
+          break;
+        }
+      }
+
+      if (msg_full) {
+        ret_ptr =
+            (uint8_t *)&persistent_self.turbidity_storage.msg_queue[i].payload;
+        return ret_ptr;
+      }
+    }
+
+    break;
+
+  case LIGHT_TELEMETRY:
+
+    // Make sure we have enough elements to constitute a full msg
+    if (persistent_self.light_storage.num_msg_elements_enqueued <
+        LIGHT_MSGS_PER_SBD) {
+      return NULL;
+    }
+
+    // Just take the first available
+    for (int i = 0; i < MAX_NUM_NON_WAVES_MSGS_STORED; i++) {
+
+      msg_full = true;
+
+      for (int j = 0; j < LIGHT_MSGS_PER_SBD; j++) {
+        if (!persistent_self.light_storage.msg_queue[i].valid[j]) {
+          msg_full = false;
+          break;
+        }
+      }
+
+      if (msg_full) {
+        ret_ptr =
+            (uint8_t *)&persistent_self.light_storage.msg_queue[i].payload;
+        return ret_ptr;
+      }
+    }
+
+    break;
+
+  default:
+    ret_ptr = NULL;
   }
 
   return ret_ptr;
 }
 
-void persistent_ram_delete_message_element ( telemetry_type_t msg_type, uint8_t *msg_ptr )
-{
+void persistent_ram_delete_message_element(telemetry_type_t msg_type,
+                                           uint8_t *msg_ptr) {
   // Corruption, lack of initialization check
-  if ( persistent_self.magic_number != PERSISTENT_RAM_MAGIC_DOUBLE_WORD )
-  {
-    _persistent_ram_clear ();
+  if (persistent_self.magic_number != PERSISTENT_RAM_MAGIC_DOUBLE_WORD) {
+    _persistent_ram_clear();
     return;
   }
 
-  switch ( msg_type )
-  {
-    case WAVES_TELEMETRY:
+  switch (msg_type) {
+  case WAVES_TELEMETRY:
 
-      // Find the pointer
-      for ( int i = 0; i < MAX_NUM_WAVES_MSGS_STORED; i++ )
-      {
-        if ( (uint8_t*) &persistent_self.waves_storage.msg_queue[i].payload == msg_ptr )
-        {
-          // Zero out the message
-          memset (msg_ptr, 0, sizeof(Iridium_Message_Storage_Element_t));
-          persistent_self.waves_storage.num_telemetry_msgs_enqueued--;
-          break;
-        }
+    // Find the pointer
+    for (int i = 0; i < MAX_NUM_WAVES_MSGS_STORED; i++) {
+      if ((uint8_t *)&persistent_self.waves_storage.msg_queue[i].payload ==
+          msg_ptr) {
+        // Zero out the message
+        memset(msg_ptr, 0, sizeof(Iridium_Message_Storage_Element_t));
+        persistent_self.waves_storage.num_telemetry_msgs_enqueued--;
+        break;
       }
+    }
 
-      break;
+    break;
 
-    case ACCELEROMETER_TELEMETRY:
+  case ACCELEROMETER_TELEMETRY:
 
-      // Find the pointer
-      for ( int i = 0; i < MAX_NUM_ACCELEROMETER_MSGS_STORED; i++ )
-      {
-        if ( (uint8_t*) &persistent_self.accelerometer_storage.msg_queue[i].payload == msg_ptr )
-        {
-          // Zero out the message
-          memset (msg_ptr, 0, sizeof(Accelerometer_Message_Storage_Element_t));
-          persistent_self.accelerometer_storage.num_telemetry_msgs_enqueued--;
-          break;
-        }
+    // Find the pointer
+    for (int i = 0; i < MAX_NUM_ACCELEROMETER_MSGS_STORED; i++) {
+      if ((uint8_t *)&persistent_self.accelerometer_storage.msg_queue[i]
+              .payload == msg_ptr) {
+        // Zero out the message
+        memset(msg_ptr, 0, sizeof(Accelerometer_Message_Storage_Element_t));
+        persistent_self.accelerometer_storage.num_telemetry_msgs_enqueued--;
+        break;
       }
+    }
 
-      break;
+    break;
 
-    case TURBIDITY_TELEMETRY:
+  case TURBIDITY_TELEMETRY:
 
-      // Find the pointer
-      for ( int i = 0; i < MAX_NUM_NON_WAVES_MSGS_STORED; i++ )
-      {
-        if ( (uint8_t*) &persistent_self.turbidity_storage.msg_queue[i].payload == msg_ptr )
-        {
-          // Zero out the message
-          memset (msg_ptr, 0, sizeof(Turbidity_Message_Storage_Element_t));
-          persistent_self.turbidity_storage.num_msg_elements_enqueued -= TURBIDITY_MSGS_PER_SBD;
-          break;
-        }
+    // Find the pointer
+    for (int i = 0; i < MAX_NUM_NON_WAVES_MSGS_STORED; i++) {
+      if ((uint8_t *)&persistent_self.turbidity_storage.msg_queue[i].payload ==
+          msg_ptr) {
+        // Zero out the message
+        memset(msg_ptr, 0, sizeof(Turbidity_Message_Storage_Element_t));
+        persistent_self.turbidity_storage.num_msg_elements_enqueued -=
+            TURBIDITY_MSGS_PER_SBD;
+        break;
       }
+    }
 
-      break;
+    break;
 
-    case LIGHT_TELEMETRY:
+  case LIGHT_TELEMETRY:
 
-      // Find the pointer
-      for ( int i = 0; i < MAX_NUM_NON_WAVES_MSGS_STORED; i++ )
-      {
-        if ( (uint8_t*) &persistent_self.light_storage.msg_queue[i].payload == msg_ptr )
-        {
-          // Zero out the message
-          memset (msg_ptr, 0, sizeof(Light_Message_Storage_Element_t));
-          persistent_self.light_storage.num_msg_elements_enqueued -= LIGHT_MSGS_PER_SBD;
-          break;
-        }
+    // Find the pointer
+    for (int i = 0; i < MAX_NUM_NON_WAVES_MSGS_STORED; i++) {
+      if ((uint8_t *)&persistent_self.light_storage.msg_queue[i].payload ==
+          msg_ptr) {
+        // Zero out the message
+        memset(msg_ptr, 0, sizeof(Light_Message_Storage_Element_t));
+        persistent_self.light_storage.num_msg_elements_enqueued -=
+            LIGHT_MSGS_PER_SBD;
+        break;
       }
+    }
 
-      break;
+    break;
 
-    case OTA_ACK_MESSAGE:
-      persistent_self.ota_acknowledgement_sent = true;
-      memset (&persistent_self.ota_acknowledgement_msg, 0, sizeof(sbd_message_type_99));
-      break;
+  case OTA_ACK_MESSAGE:
+    persistent_self.ota_acknowledgement_sent = true;
+    memset(&persistent_self.ota_acknowledgement_msg, 0,
+           sizeof(sbd_message_type_99));
+    break;
 
-    default:
-      break;
+  default:
+    break;
   }
 }
 
-static void _persistent_ram_clear ( void )
-{
+static void _persistent_ram_clear(void) {
   // Clear everything out
-  memset (&persistent_self, 0, sizeof(Persistent_Storage));
+  memset(&persistent_self, 0, sizeof(Persistent_Storage));
 }

--- a/Core/Src/persistent_ram.c
+++ b/Core/Src/persistent_ram.c
@@ -300,6 +300,9 @@ void persistent_ram_save_message(telemetry_type_t msg_type, float msg_priority,
       }
     }
 
+    LOG("Found minimum accel priority of %0.6f at position %d in queue\r\n",
+        min_priority, min_priority_idx);
+
     if (min_priority_idx >= 0 && msg_priority > min_priority) {
       // copy the message over
       memcpy(
@@ -312,6 +315,9 @@ void persistent_ram_save_message(telemetry_type_t msg_type, float msg_priority,
       // need to increment message count IF we're not replacing an existing one
       if (min_priority < 0) {
         persistent_self.accel_storage.num_telemetry_msgs_enqueued++;
+        LOG("Filling empty slot; increment num accel msgs enqueued");
+      } else {
+        LOG("Replacing existing message; don't increment accel msgs enqueued");
       }
     } else {
       LOG("Cannot enqueue accel msg with priority %0.6f; min priority in queue "
@@ -577,6 +583,8 @@ void persistent_ram_delete_message_element(telemetry_type_t msg_type,
         ((Accelerometer_Message_Storage_Element_t *)msg_ptr)->priority = -1;
         persistent_self.accel_storage.num_telemetry_msgs_enqueued--;
         break;
+      } else {
+        LOG("Unable to remove Accel message!");
       }
     }
     break; // case ACCELEROMETER_TELEMETRY

--- a/Core/Src/persistent_ram.c
+++ b/Core/Src/persistent_ram.c
@@ -59,17 +59,6 @@ void persistent_ram_init(const microSWIFT_configuration *config,
   else {
     persistent_self.sample_window_counter++;
   }
-
-  // Initialize the priority queues.
-  // * Previously the "valid" flag had been set to False by the clearing
-  //   function setting all memory to 0.
-  // * Light and Turbidity have a plain queue, no prioritization.
-  for (int ii = 0; ii < MAX_NUM_ACCELEROMETER_MSGS_STORED; ii++) {
-    persistent_self.accel_storage.msg_queue[ii].priority = -1;
-  }
-  for (int ii = 0; ii < MAX_NUM_WAVES_MSGS_STORED; ii++) {
-    persistent_self.waves_storage.msg_queue[ii].priority = -1;
-  }
 }
 
 /**
@@ -642,4 +631,14 @@ VOID persistent_ram_get_accel_priorities(float *priorities) {
 static void _persistent_ram_clear(void) {
   // Clear everything out
   memset(&persistent_self, 0, sizeof(Persistent_Storage));
+  // Initialize the priority queues.
+  // * Previously the "valid" flag had been set to False by the clearing
+  //   function setting all memory to 0.
+  // * Light and Turbidity have a plain queue, no prioritization.
+  for (int ii = 0; ii < MAX_NUM_ACCELEROMETER_MSGS_STORED; ii++) {
+    persistent_self.accel_storage.msg_queue[ii].priority = -1;
+  }
+  for (int ii = 0; ii < MAX_NUM_WAVES_MSGS_STORED; ii++) {
+    persistent_self.waves_storage.msg_queue[ii].priority = -1;
+  }
 }

--- a/Core/Src/persistent_ram.c
+++ b/Core/Src/persistent_ram.c
@@ -635,6 +635,12 @@ void persistent_ram_delete_message_element(telemetry_type_t msg_type,
   }
 }
 
+VOID persistent_ram_get_accel_priorities(float *priorities) {
+  for (int ii = 0; ii < MAX_NUM_ACCELEROMETER_MSGS_STORED; ii++) {
+    priorities[ii] = persistent_self.accel_storage.msg_queue[ii].priority;
+  }
+}
+
 static void _persistent_ram_clear(void) {
   // Clear everything out
   memset(&persistent_self, 0, sizeof(Persistent_Storage));

--- a/Core/Src/persistent_ram.c
+++ b/Core/Src/persistent_ram.c
@@ -12,6 +12,7 @@
 #include "string.h"
 #include "time.h"
 #include <ext_rtc_server.h>
+#include <limits.h>
 
 // Save the struct in SRAM2 -- NOLOAD section which will be retained in standby
 // mode
@@ -57,6 +58,17 @@ void persistent_ram_init(const microSWIFT_configuration *config,
   // Otherwise increment it
   else {
     persistent_self.sample_window_counter++;
+  }
+
+  // Initialize the priority queues.
+  // * Previously the "valid" flag had been set to False by the clearing
+  //   function setting all memory to 0.
+  // * Light and Turbidity have a plain queue, no prioritization.
+  for (int ii = 0; ii < MAX_NUM_ACCELEROMETER_MSGS_STORED; ii++) {
+    persistent_self.accel_storage.msg_queue[ii].priority = -1;
+  }
+  for (int ii = 0; ii < MAX_NUM_WAVES_MSGS_STORED; ii++) {
+    persistent_self.waves_storage.msg_queue[ii].priority = -1;
   }
 }
 
@@ -229,8 +241,8 @@ uint32_t persistent_ram_get_num_msgs_enqueued(telemetry_type_t msg_type) {
 
   case ACCELEROMETER_TELEMETRY:
     LOG("Number of enqueued Accelerometer messages: %lu",
-        persistent_self.accelerometer_storage.num_telemetry_msgs_enqueued);
-    return persistent_self.accelerometer_storage.num_telemetry_msgs_enqueued;
+        persistent_self.accel_storage.num_telemetry_msgs_enqueued);
+    return persistent_self.accel_storage.num_telemetry_msgs_enqueued;
     break;
 
   default:
@@ -255,166 +267,156 @@ void persistent_ram_save_message(telemetry_type_t msg_type, float msg_priority,
     _persistent_ram_clear();
   }
 
+  // Minimum priority in the queue
+  float min_priority = FLT_MAX;
+  // Index of minimum priority; where data will be inserted
+  int min_priority_idx = -1;
+
   switch (msg_type) {
+
   case WAVES_TELEMETRY:
-    // If the storage queue is full, see if we can replace an element
-    if (persistent_self.waves_storage.num_telemetry_msgs_enqueued ==
-        MAX_NUM_WAVES_MSGS_STORED) {
-      for (i = 0; i < MAX_NUM_WAVES_MSGS_STORED; i++) {
-        // Want to make sure we are comparing absolute values, though wave
-        // height should always be positive
-        if ((fabsf(halfToFloat(
-                persistent_self.waves_storage.msg_queue[i].payload.Hs))) <
-            fabsf(halfToFloat(((sbd_message_type_52 *)msg)->Hs))) {
-          // copy the message over
-          memcpy(&(persistent_self.waves_storage.msg_queue[i].payload), msg,
-                 sizeof(sbd_message_type_52));
-          // Make the entry valid (should already be, but just in case)
-          persistent_self.waves_storage.msg_queue[i].valid = true;
-          return;
-        }
-      }
-    } else {
-      // Not full, just need to find an open slot
-      for (i = 0; i < MAX_NUM_WAVES_MSGS_STORED; i++) {
-        if (!persistent_self.waves_storage.msg_queue[i].valid) {
-          // copy the message over
-          memcpy(&(persistent_self.waves_storage.msg_queue[i].payload), msg,
-                 sizeof(sbd_message_type_52));
-          // Make the entry valid
-          persistent_self.waves_storage.msg_queue[i].valid = true;
-          persistent_self.waves_storage.num_telemetry_msgs_enqueued++;
-          return;
+    for (int ii = 0; ii < MAX_NUM_WAVES_MSGS_STORED; ii++) {
+      if (persistent_self.waves_storage.msg_queue[ii].priority < min_priority) {
+        min_priority = persistent_self.waves_storage.msg_queue[ii].priority;
+        min_priority_idx = ii;
+        if (min_priority < 0) {
+          // short-circuit search if we've found an empty slot
+          break;
         }
       }
     }
+    if (min_priority_idx >= 0 && msg_priority > min_priority) {
+      memcpy(
+          &(persistent_self.waves_storage.msg_queue[min_priority_idx].payload),
+          msg, sizeof(sbd_message_type_52));
+      persistent_self.waves_storage.msg_queue[min_priority_idx].priority =
+          msg_priority;
 
-    break;
+      // If NOT replacing a valid message, increment num enqueued
+      if (min_priority < 0) {
+        persistent_self.waves_storage.num_telemetry_msgs_enqueued++;
+      }
+    }
+    break; // case WAVES_TELEMETRY
 
   case ACCELEROMETER_TELEMETRY:
-    // If the storage queue is full, see if we can replace an element
-    if (persistent_self.accelerometer_storage.num_telemetry_msgs_enqueued ==
-        MAX_NUM_ACCELEROMETER_MSGS_STORED) {
-      for (i = 0; i < MAX_NUM_ACCELEROMETER_MSGS_STORED; i++) {
-        // TODO: Ask Jim what metric to use here since we do not calculate
-        //       wave heights for accelerometer data.
-        // NOTE: The previous logic simply replaces the first message with
-        //       smaller wave heights; instead, it might make sense to
-        //       replace the absolute smallest element.
-        if ((fabsf(
-                halfToFloat(persistent_self.accelerometer_storage.msg_queue[i]
-                                .payload.max_z_accel))) <
-            fabsf(halfToFloat(((sbd_message_type_55 *)msg)->max_z_accel))) {
-          // copy the message over
-          memcpy(&(persistent_self.accelerometer_storage.msg_queue[i].payload),
-                 msg, sizeof(sbd_message_type_55));
-          // Make the entry valid (should already be, but just in case)
-          persistent_self.accelerometer_storage.msg_queue[i].valid = true;
-          return;
+
+    // Find minimum value and index in queue
+    for (int ii = 0; ii < MAX_NUM_ACCELEROMETER_MSGS_STORED; ii++) {
+      if (persistent_self.accel_storage.msg_queue[ii].priority < min_priority) {
+        min_priority = persistent_self.accel_storage.msg_queue[ii].priority;
+        min_priority_idx = ii;
+        if (min_priority < 0) {
+          // short-circuit search if we've found an empty slot
+          break;
         }
       }
-      // Do we want to log that we're discarding a message due to full queue?
-    } else {
-      // Not full, just need to find an open slot
-      for (i = 0; i < MAX_NUM_ACCELEROMETER_MSGS_STORED; i++) {
-        if (!persistent_self.accelerometer_storage.msg_queue[i].valid) {
-          // copy the message over
-          memcpy(&(persistent_self.accelerometer_storage.msg_queue[i].payload),
-                 msg, sizeof(sbd_message_type_55));
-          // Make the entry valid
-          persistent_self.accelerometer_storage.msg_queue[i].valid = true;
-          persistent_self.accelerometer_storage.num_telemetry_msgs_enqueued++;
-          return;
-        }
-      }
-      // Getting here would indicate an error -- should we log that?
     }
 
-    break;
+    if (min_priority_idx >= 0 && msg_priority > min_priority) {
+      // copy the message over
+      memcpy(
+          &(persistent_self.accel_storage.msg_queue[min_priority_idx].payload),
+          msg, sizeof(sbd_message_type_55));
+      persistent_self.accel_storage.msg_queue[min_priority_idx].priority =
+          msg_priority;
+      LOG("Queued msg with priority %0.6f and position %d", msg_priority,
+          min_priority_idx);
+      // need to increment message count IF we're not replacing an existing one
+      if (min_priority < 0) {
+        persistent_self.accel_storage.num_telemetry_msgs_enqueued++;
+      }
+    } else {
+      LOG("Cannot enqueue accel msg with priority %0.6f; min priority in queue "
+          "= %0.6f",
+          msg_priority, min_priority);
+    }
+    break; // case ACCELEROMETER_TELEMETRY
 
   case TURBIDITY_TELEMETRY:
     // If the storage queue is full, then just skip
-    if (!(persistent_self.turbidity_storage.num_msg_elements_enqueued ==
-          MAX_NUM_TURBIDITY_MSGS_STORED)) {
-      // First check if there is room in the current message index
-      for (i = 0; i < TURBIDITY_MSGS_PER_SBD; i++) {
-        if (!persistent_self.turbidity_storage
-                 .msg_queue[persistent_self.turbidity_storage.current_msg_index]
-                 .valid[i]) {
-          // copy the message over
-          memcpy(&(persistent_self.turbidity_storage
-                       .msg_queue[persistent_self.turbidity_storage
-                                      .current_msg_index]
-                       .payload.elements[i]),
-                 msg, sizeof(sbd_message_type_53_element));
-          // Make the entry valid
-          persistent_self.turbidity_storage
-              .msg_queue[persistent_self.turbidity_storage.current_msg_index]
-              .valid[i] = true;
-          persistent_self.turbidity_storage.num_msg_elements_enqueued++;
-          return;
-        }
-      }
-
-      // Need to start a new message
-      for (i = 0; i < MAX_NUM_NON_WAVES_MSGS_STORED; i++) {
-        if (!persistent_self.turbidity_storage.msg_queue[i].valid[0]) {
-          // copy the message over
-          memcpy(&(persistent_self.turbidity_storage.msg_queue[i]
-                       .payload.elements[0]),
-                 msg, sizeof(sbd_message_type_53_element));
-          // Make the entry valid
-          persistent_self.turbidity_storage.msg_queue[i].valid[0] = true;
-          persistent_self.turbidity_storage.num_msg_elements_enqueued++;
-          persistent_self.turbidity_storage.current_msg_index = i;
-          return;
-        }
+    if ((persistent_self.turbidity_storage.num_msg_elements_enqueued ==
+         MAX_NUM_TURBIDITY_MSGS_STORED)) {
+      return;
+    }
+    // First check if there is room in the current message index
+    for (int ii = 0; ii < TURBIDITY_MSGS_PER_SBD; ii++) {
+      if (!persistent_self.turbidity_storage
+               .msg_queue[persistent_self.turbidity_storage.current_msg_index]
+               .valid[ii]) {
+        // copy the message over
+        memcpy(&(persistent_self.turbidity_storage
+                     .msg_queue[persistent_self.turbidity_storage
+                                    .current_msg_index]
+                     .payload.elements[ii]),
+               msg, sizeof(sbd_message_type_53_element));
+        // Make the entry valid
+        persistent_self.turbidity_storage
+            .msg_queue[persistent_self.turbidity_storage.current_msg_index]
+            .valid[ii] = true;
+        persistent_self.turbidity_storage.num_msg_elements_enqueued++;
+        return;
       }
     }
 
-    break;
+    // Need to start a new message
+    for (int ii = 0; ii < MAX_NUM_NON_WAVES_MSGS_STORED; ii++) {
+      if (!persistent_self.turbidity_storage.msg_queue[ii].valid[0]) {
+        // copy the message over
+        memcpy(&(persistent_self.turbidity_storage.msg_queue[ii]
+                     .payload.elements[0]),
+               msg, sizeof(sbd_message_type_53_element));
+        // Make the entry valid
+        persistent_self.turbidity_storage.msg_queue[ii].valid[0] = true;
+        persistent_self.turbidity_storage.num_msg_elements_enqueued++;
+        persistent_self.turbidity_storage.current_msg_index = ii;
+        return;
+      }
+    }
+
+    break; // case TURBIDITY_TELEMETRY
 
   case LIGHT_TELEMETRY:
     // If the storage queue is full, then just skip
-    if (!(persistent_self.light_storage.num_msg_elements_enqueued ==
-          MAX_NUM_LIGHT_MSGS_STORED)) {
-      // First check if there is room in the current message index
-      for (i = 0; i < LIGHT_MSGS_PER_SBD; i++) {
-        if (!persistent_self.light_storage
-                 .msg_queue[persistent_self.light_storage.current_msg_index]
-                 .valid[i]) {
-          // copy the message over
-          memcpy(
-              &(persistent_self.light_storage
-                    .msg_queue[persistent_self.light_storage.current_msg_index]
-                    .payload.elements[i]),
-              msg, sizeof(sbd_message_type_54_element));
-          // Make the entry valid
-          persistent_self.light_storage
-              .msg_queue[persistent_self.light_storage.current_msg_index]
-              .valid[i] = true;
-          persistent_self.light_storage.num_msg_elements_enqueued++;
-          return;
-        }
-      }
-
-      // Need to start a new message
-      for (i = 0; i < MAX_NUM_NON_WAVES_MSGS_STORED; i++) {
-        if (!persistent_self.light_storage.msg_queue[i].valid[0]) {
-          // copy the message over
-          memcpy(
-              &(persistent_self.light_storage.msg_queue[i].payload.elements[0]),
-              msg, sizeof(sbd_message_type_54_element));
-          // Make the entry valid
-          persistent_self.light_storage.msg_queue[i].valid[0] = true;
-          persistent_self.light_storage.num_msg_elements_enqueued++;
-          persistent_self.light_storage.current_msg_index = i;
-          return;
-        }
+    if ((persistent_self.light_storage.num_msg_elements_enqueued ==
+         MAX_NUM_LIGHT_MSGS_STORED)) {
+      return;
+    }
+    // First check if there is room in the current message index
+    for (int ii = 0; ii < LIGHT_MSGS_PER_SBD; ii++) {
+      if (!persistent_self.light_storage
+               .msg_queue[persistent_self.light_storage.current_msg_index]
+               .valid[ii]) {
+        // copy the message over
+        memcpy(&(persistent_self.light_storage
+                     .msg_queue[persistent_self.light_storage.current_msg_index]
+                     .payload.elements[ii]),
+               msg, sizeof(sbd_message_type_54_element));
+        // Make the entry valid
+        persistent_self.light_storage
+            .msg_queue[persistent_self.light_storage.current_msg_index]
+            .valid[ii] = true;
+        persistent_self.light_storage.num_msg_elements_enqueued++;
+        return;
       }
     }
 
-    break;
+    // Need to start a new message
+    for (int ii = 0; ii < MAX_NUM_NON_WAVES_MSGS_STORED; ii++) {
+      if (!persistent_self.light_storage.msg_queue[ii].valid[0]) {
+        // copy the message over
+        memcpy(
+            &(persistent_self.light_storage.msg_queue[ii].payload.elements[0]),
+            msg, sizeof(sbd_message_type_54_element));
+        // Make the entry valid
+        persistent_self.light_storage.msg_queue[ii].valid[0] = true;
+        persistent_self.light_storage.num_msg_elements_enqueued++;
+        persistent_self.light_storage.current_msg_index = ii;
+        return;
+      }
+    }
+
+    break; // case LIGHT_TELEMETRY
 
   default:
     return;
@@ -431,15 +433,9 @@ void persistent_ram_save_message(telemetry_type_t msg_type, float msg_priority,
  */
 uint8_t *
 persistent_ram_get_prioritized_unsent_message(telemetry_type_t msg_type) {
-  // Set to float min value to ensure any message significant wave height will
-  // be greater than or equal to
-  float most_significant_wave_height = -FLT_MAX;
-  float msg_wave_height = 0.0;
-  real16_T msg_wave_half_float = {0};
-  float max_z_accel = -FLT_MAX;
-  float msg_z_accel = 0.0;
-  real16_T msg_accel_half_float = {0};
-  int32_t pri_msg_index = 0, valid_msg_index = -1;
+  float max_priority = -FLT_MAX;
+  int max_priority_idx = -1;
+
   bool msg_full = false;
   uint8_t *ret_ptr = NULL;
 
@@ -457,85 +453,49 @@ persistent_ram_get_prioritized_unsent_message(telemetry_type_t msg_type) {
       return NULL;
     }
 
-    // Find the largest significant wave height
-    for (int i = 0; i < MAX_NUM_WAVES_MSGS_STORED; i++) {
-      if (persistent_self.waves_storage.msg_queue[i].valid) {
-        valid_msg_index = i;
-        msg_wave_half_float =
-            persistent_self.waves_storage.msg_queue[i].payload.Hs;
-        msg_wave_height = fabsf(halfToFloat(msg_wave_half_float));
-
-        if (msg_wave_height >= most_significant_wave_height) {
-          most_significant_wave_height = msg_wave_height;
-          pri_msg_index = i;
-        }
+    // Find the highest priority message
+    for (int ii = 0; ii < MAX_NUM_WAVES_MSGS_STORED; ii++) {
+      if (persistent_self.waves_storage.msg_queue[ii].priority > max_priority) {
+        max_priority = persistent_self.waves_storage.msg_queue[ii].priority;
+        max_priority_idx = ii;
       }
     }
 
-    // Make sure we don't go out of bounds. Take the priority message first,
-    // otherwise, any valid message
-    if ((pri_msg_index >= 0) &&
-        (pri_msg_index <= (MAX_NUM_WAVES_MSGS_STORED - 1))) {
+    if (0 <= max_priority_idx && max_priority_idx < MAX_NUM_WAVES_MSGS_STORED) {
       ret_ptr =
-          (uint8_t *)&persistent_self.waves_storage.msg_queue[pri_msg_index]
-              .payload;
-    } else if ((valid_msg_index >= 0) &&
-               (valid_msg_index <= (MAX_NUM_WAVES_MSGS_STORED - 1))) {
-      ret_ptr =
-          (uint8_t *)&persistent_self.waves_storage.msg_queue[valid_msg_index]
+          (uint8_t *)&persistent_self.waves_storage.msg_queue[max_priority_idx]
               .payload;
     } else {
       ret_ptr = NULL;
     }
+    break; // case WAVES_TELEMETRY
 
-    break;
-
-  // This is a clone of the WAVES_TELEMETRY logic
   case ACCELEROMETER_TELEMETRY:
 
     // Empty queue check
-    if (persistent_self.accelerometer_storage.num_telemetry_msgs_enqueued ==
-        0) {
+    if (persistent_self.accel_storage.num_telemetry_msgs_enqueued == 0) {
       return NULL;
     }
 
-    // Find the maximum acceleration in Z.
-    // TODO: Update this prioritization.
-    for (int i = 0; i < MAX_NUM_ACCELEROMETER_MSGS_STORED; i++) {
-      if (persistent_self.accelerometer_storage.msg_queue[i].valid) {
-        valid_msg_index = i;
-        msg_accel_half_float =
-            persistent_self.accelerometer_storage.msg_queue[i]
-                .payload.max_z_accel;
-        msg_z_accel = fabsf(halfToFloat(msg_accel_half_float));
-
-        if (msg_z_accel >= max_z_accel) {
-          max_z_accel = msg_z_accel;
-          pri_msg_index = i;
-        }
+    for (int ii = 0; ii < MAX_NUM_ACCELEROMETER_MSGS_STORED; ii++) {
+      if (persistent_self.accel_storage.msg_queue[ii].priority > max_priority) {
+        max_priority = persistent_self.accel_storage.msg_queue[ii].priority;
+        max_priority_idx = ii;
       }
     }
 
-    // Make sure we don't go out of bounds. Take the priority message first,
-    // otherwise, any valid message
-    if ((pri_msg_index >= 0) &&
-        (pri_msg_index <= (MAX_NUM_ACCELEROMETER_MSGS_STORED - 1))) {
-      ret_ptr = (uint8_t *)&persistent_self.accelerometer_storage
-                    .msg_queue[pri_msg_index]
-                    .payload;
-    } else if ((valid_msg_index >= 0) &&
-               (valid_msg_index <= (MAX_NUM_ACCELEROMETER_MSGS_STORED - 1))) {
-      ret_ptr = (uint8_t *)&persistent_self.accelerometer_storage
-                    .msg_queue[valid_msg_index]
-                    .payload;
+    if (max_priority_idx >= 0 &&
+        max_priority_idx < MAX_NUM_ACCELEROMETER_MSGS_STORED) {
+      ret_ptr =
+          (uint8_t *)&persistent_self.accel_storage.msg_queue[max_priority_idx]
+              .payload;
     } else {
       ret_ptr = NULL;
     }
 
-    break;
+    break; // case ACCELEROMETER_TELEMETRY
 
   case TURBIDITY_TELEMETRY:
-
     // Make sure we have enough elements to constitute a full msg
     if (persistent_self.turbidity_storage.num_msg_elements_enqueued <
         TURBIDITY_MSGS_PER_SBD) {
@@ -543,41 +503,34 @@ persistent_ram_get_prioritized_unsent_message(telemetry_type_t msg_type) {
     }
 
     // Just take the first available
-    for (int i = 0; i < MAX_NUM_NON_WAVES_MSGS_STORED; i++) {
-
+    // NOTE(LEL): I think this effectively becomes a LIFO queue
+    for (int ii = 0; ii < MAX_NUM_NON_WAVES_MSGS_STORED; ii++) {
       msg_full = true;
-
-      for (int j = 0; j < TURBIDITY_MSGS_PER_SBD; j++) {
-        if (!persistent_self.turbidity_storage.msg_queue[i].valid[j]) {
+      for (int jj = 0; jj < TURBIDITY_MSGS_PER_SBD; jj++) {
+        if (!persistent_self.turbidity_storage.msg_queue[ii].valid[jj]) {
           msg_full = false;
           break;
         }
       }
-
       if (msg_full) {
         ret_ptr =
-            (uint8_t *)&persistent_self.turbidity_storage.msg_queue[i].payload;
+            (uint8_t *)&persistent_self.turbidity_storage.msg_queue[ii].payload;
         return ret_ptr;
       }
     }
-
-    break;
+    break; // case TURBIDITY_TELEMETRY
 
   case LIGHT_TELEMETRY:
-
     // Make sure we have enough elements to constitute a full msg
     if (persistent_self.light_storage.num_msg_elements_enqueued <
         LIGHT_MSGS_PER_SBD) {
       return NULL;
     }
-
     // Just take the first available
-    for (int i = 0; i < MAX_NUM_NON_WAVES_MSGS_STORED; i++) {
-
+    for (int ii = 0; ii < MAX_NUM_NON_WAVES_MSGS_STORED; ii++) {
       msg_full = true;
-
-      for (int j = 0; j < LIGHT_MSGS_PER_SBD; j++) {
-        if (!persistent_self.light_storage.msg_queue[i].valid[j]) {
+      for (int jj = 0; jj < LIGHT_MSGS_PER_SBD; jj++) {
+        if (!persistent_self.light_storage.msg_queue[ii].valid[jj]) {
           msg_full = false;
           break;
         }
@@ -585,12 +538,12 @@ persistent_ram_get_prioritized_unsent_message(telemetry_type_t msg_type) {
 
       if (msg_full) {
         ret_ptr =
-            (uint8_t *)&persistent_self.light_storage.msg_queue[i].payload;
+            (uint8_t *)&persistent_self.light_storage.msg_queue[ii].payload;
         return ret_ptr;
       }
     }
 
-    break;
+    break; // case LIGHT_TELEMETRY
 
   default:
     ret_ptr = NULL;
@@ -599,6 +552,9 @@ persistent_ram_get_prioritized_unsent_message(telemetry_type_t msg_type) {
   return ret_ptr;
 }
 
+// We don't pop from the queue because we only want to remove an element
+// after it has been transmitted successfully. So we have a {get, delete}
+// in place of the more traditional {peek, pop}.
 void persistent_ram_delete_message_element(telemetry_type_t msg_type,
                                            uint8_t *msg_ptr) {
   // Corruption, lack of initialization check
@@ -611,32 +567,32 @@ void persistent_ram_delete_message_element(telemetry_type_t msg_type,
   case WAVES_TELEMETRY:
 
     // Find the pointer
-    for (int i = 0; i < MAX_NUM_WAVES_MSGS_STORED; i++) {
-      if ((uint8_t *)&persistent_self.waves_storage.msg_queue[i].payload ==
+    for (int ii = 0; ii < MAX_NUM_WAVES_MSGS_STORED; ii++) {
+      if ((uint8_t *)&persistent_self.waves_storage.msg_queue[ii].payload ==
           msg_ptr) {
         // Zero out the message
         memset(msg_ptr, 0, sizeof(Iridium_Message_Storage_Element_t));
+        ((Iridium_Message_Storage_Element_t *)msg_ptr)->priority = -1;
         persistent_self.waves_storage.num_telemetry_msgs_enqueued--;
         break;
       }
     }
-
-    break;
+    break; // case WAVES_TELEMETRY
 
   case ACCELEROMETER_TELEMETRY:
 
     // Find the pointer
     for (int i = 0; i < MAX_NUM_ACCELEROMETER_MSGS_STORED; i++) {
-      if ((uint8_t *)&persistent_self.accelerometer_storage.msg_queue[i]
-              .payload == msg_ptr) {
+      if ((uint8_t *)&persistent_self.accel_storage.msg_queue[i].payload ==
+          msg_ptr) {
         // Zero out the message
         memset(msg_ptr, 0, sizeof(Accelerometer_Message_Storage_Element_t));
-        persistent_self.accelerometer_storage.num_telemetry_msgs_enqueued--;
+        ((Accelerometer_Message_Storage_Element_t *)msg_ptr)->priority = -1;
+        persistent_self.accel_storage.num_telemetry_msgs_enqueued--;
         break;
       }
     }
-
-    break;
+    break; // case ACCELEROMETER_TELEMETRY
 
   case TURBIDITY_TELEMETRY:
 
@@ -651,8 +607,7 @@ void persistent_ram_delete_message_element(telemetry_type_t msg_type,
         break;
       }
     }
-
-    break;
+    break; // case TURBIDITY_TELEMETRY
 
   case LIGHT_TELEMETRY:
 
@@ -667,8 +622,7 @@ void persistent_ram_delete_message_element(telemetry_type_t msg_type,
         break;
       }
     }
-
-    break;
+    break; // case LIGHT_TELEMETRY
 
   case OTA_ACK_MESSAGE:
     persistent_self.ota_acknowledgement_sent = true;

--- a/Core/Src/persistent_ram.c
+++ b/Core/Src/persistent_ram.c
@@ -260,8 +260,6 @@ uint32_t persistent_ram_get_num_msgs_enqueued(telemetry_type_t msg_type) {
 
 void persistent_ram_save_message(telemetry_type_t msg_type, float msg_priority,
                                  uint8_t *msg) {
-  int i = 0;
-
   // Corruption, lack of initialization check
   if (persistent_self.magic_number != PERSISTENT_RAM_MAGIC_DOUBLE_WORD) {
     _persistent_ram_clear();

--- a/Core/Src/testing_hooks.c
+++ b/Core/Src/testing_hooks.c
@@ -92,15 +92,16 @@ bool test_iridium_queueing(void *iridium_ptr) {
 
   // Make a bunch of type 52 messages, half with error values, half with an
   // increasing significant wave height
+  float priority = 1;
   for (int i = 0; i < 10; i++) {
     Hs.bitPattern = (i % 2 == 0) ? TELEMETRY_FIELD_ERROR_CODE : 0x4248 + i;
     memcpy(&sbd_message.Hs, &Hs, sizeof(real16_T));
 
-    persistent_ram_save_message(WAVES_TELEMETRY, (uint8_t *)&sbd_message);
+    persistent_ram_save_message(WAVES_TELEMETRY, priority,
+                                (uint8_t *)&sbd_message);
   }
 
   memcpy(&(msg_buffer[0]), &sbd_message, sizeof(sbd_message_type_52));
-
   for (int i = 0; i < 10 * LIGHT_MSGS_PER_SBD; i++) {
     memset(&light_message.start_lat, i + 1, sizeof(uint8_t));
     memset(&light_message.start_lon, i + 1, sizeof(uint8_t));
@@ -121,7 +122,8 @@ bool test_iridium_queueing(void *iridium_ptr) {
     memset(&light_message.avg_f8, i + 1, sizeof(uint8_t));
     memset(&light_message.avg_dark, i + 1, sizeof(uint8_t));
     memset(&light_message.avg_nir, i + 1, sizeof(uint8_t));
-    persistent_ram_save_message(LIGHT_TELEMETRY, (uint8_t *)&light_message);
+    persistent_ram_save_message(LIGHT_TELEMETRY, priority,
+                                (uint8_t *)&light_message);
   }
 
   watchdog_check_in(IRIDIUM_THREAD);

--- a/Core/Src/testing_hooks.c
+++ b/Core/Src/testing_hooks.c
@@ -6,34 +6,35 @@
  */
 
 #include "testing_hooks.h"
-#include "stddef.h"
-#include "ext_rtc.h"
+#include "NEDWaves/NEDwaves_memlight.h"
+#include "NEDWaves/mem_replacements.h"
 #include "app_threadx.h"
 #include "controller.h"
+#include "ct_sensor.h"
+#include "ext_rtc.h"
+#include "file_system_server.h"
 #include "gnss.h"
 #include "iridium.h"
 #include "logger.h"
-#include "ct_sensor.h"
-#include "file_system_server.h"
-#include "watchdog.h"
 #include "math.h"
-#include "NEDWaves/NEDwaves_memlight.h"
-#include "NEDWaves/mem_replacements.h"
+#include "stddef.h"
+#include "watchdog.h"
 
 testing_hooks tests;
 
 /*!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!*/
-/*################################## Test Declarations ###########################################*/
+/*################################## Test Declarations
+ * ###########################################*/
 /*!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!*/
-bool test_iridium_queueing ( void *iridium_ptr );
-bool test_gnss_config ( void *gnss );
-bool gnss_test_control_supplement ( void *control );
-bool test_ct_file_writing ( void *ct );
+bool test_iridium_queueing(void *iridium_ptr);
+bool test_gnss_config(void *gnss);
+bool gnss_test_control_supplement(void *control);
+bool test_ct_file_writing(void *ct);
 /**************************************************************************************************/
-/*********************************** Init --> Assign Tests ****************************************/
+/*********************************** Init --> Assign Tests
+ * ****************************************/
 /**************************************************************************************************/
-void tests_init ( void )
-{
+void tests_init(void) {
   tests.main_test = NULL;
   tests.threadx_init_test = NULL;
   tests.control_test = NULL;
@@ -48,21 +49,18 @@ void tests_init ( void )
 }
 
 /*!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!*/
-/*################################## Test Definitions ############################################*/
+/*################################## Test Definitions
+ * ############################################*/
 /*!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!*/
-bool test_iridium_queueing ( void *iridium_ptr )
-{
-  Iridium *iridium = (Iridium*) iridium_ptr;
+bool test_iridium_queueing(void *iridium_ptr) {
+  Iridium *iridium = (Iridium *)iridium_ptr;
   uSWIFT_return_code_t ret;
   bool current_message_sent = false;
   uint32_t next_message_type = NO_MESSAGE, next_message_size = 0;
   char *log_str;
-  sbd_message_type_52 sbd_message =
-    { 0 };
-  sbd_message_type_54_element light_message =
-    { 0 };
-  uint8_t msg_buffer[342] =
-    { 0 };
+  sbd_message_type_52 sbd_message = {0};
+  sbd_message_type_54_element light_message = {0};
+  uint8_t msg_buffer[342] = {0};
   uint8_t *msg_ptr;
   real16_T E[42];
   real16_T Dp;
@@ -81,102 +79,90 @@ bool test_iridium_queueing ( void *iridium_ptr )
   b_fmax.bitPattern = TELEMETRY_FIELD_ERROR_CODE;
   b_fmin.bitPattern = TELEMETRY_FIELD_ERROR_CODE;
 
-  memcpy (&sbd_message.Tp, &Tp, sizeof(real16_T));
-  memcpy (&sbd_message.Dp, &Dp, sizeof(real16_T));
-  memcpy (&(sbd_message.E_array[0]), &(E[0]), 42 * sizeof(real16_T));
-  memcpy (&sbd_message.f_min, &b_fmin, sizeof(real16_T));
-  memcpy (&sbd_message.f_max, &b_fmax, sizeof(real16_T));
-  memcpy (&(sbd_message.a1_array[0]), &(a1[0]), 42 * sizeof(signed char));
-  memcpy (&(sbd_message.b1_array[0]), &(b1[0]), 42 * sizeof(signed char));
-  memcpy (&(sbd_message.a2_array[0]), &(a2[0]), 42 * sizeof(signed char));
-  memcpy (&(sbd_message.b2_array[0]), &(b2[0]), 42 * sizeof(signed char));
-  memcpy (&(sbd_message.cf_array[0]), &(check[0]), 42 * sizeof(unsigned char));
+  memcpy(&sbd_message.Tp, &Tp, sizeof(real16_T));
+  memcpy(&sbd_message.Dp, &Dp, sizeof(real16_T));
+  memcpy(&(sbd_message.E_array[0]), &(E[0]), 42 * sizeof(real16_T));
+  memcpy(&sbd_message.f_min, &b_fmin, sizeof(real16_T));
+  memcpy(&sbd_message.f_max, &b_fmax, sizeof(real16_T));
+  memcpy(&(sbd_message.a1_array[0]), &(a1[0]), 42 * sizeof(signed char));
+  memcpy(&(sbd_message.b1_array[0]), &(b1[0]), 42 * sizeof(signed char));
+  memcpy(&(sbd_message.a2_array[0]), &(a2[0]), 42 * sizeof(signed char));
+  memcpy(&(sbd_message.b2_array[0]), &(b2[0]), 42 * sizeof(signed char));
+  memcpy(&(sbd_message.cf_array[0]), &(check[0]), 42 * sizeof(unsigned char));
 
-  // Make a bunch of type 52 messages, half with error values, half with an increasing
-  // significant wave height
-  for ( int i = 0; i < 10; i++ )
-  {
-    Hs.bitPattern = (i % 2 == 0) ?
-        TELEMETRY_FIELD_ERROR_CODE : 0x4248 + i;
-    memcpy (&sbd_message.Hs, &Hs, sizeof(real16_T));
+  // Make a bunch of type 52 messages, half with error values, half with an
+  // increasing significant wave height
+  for (int i = 0; i < 10; i++) {
+    Hs.bitPattern = (i % 2 == 0) ? TELEMETRY_FIELD_ERROR_CODE : 0x4248 + i;
+    memcpy(&sbd_message.Hs, &Hs, sizeof(real16_T));
 
-    persistent_ram_save_message (WAVES_TELEMETRY, (uint8_t*) &sbd_message);
+    persistent_ram_save_message(WAVES_TELEMETRY, (uint8_t *)&sbd_message);
   }
 
-  memcpy (&(msg_buffer[0]), &sbd_message, sizeof(sbd_message_type_52));
+  memcpy(&(msg_buffer[0]), &sbd_message, sizeof(sbd_message_type_52));
 
-  for ( int i = 0; i < 10 * LIGHT_MSGS_PER_SBD; i++ )
-  {
-    memset (&light_message.start_lat, i + 1, sizeof(uint8_t));
-    memset (&light_message.start_lon, i + 1, sizeof(uint8_t));
-    memset (&light_message.end_lat, i + 1, sizeof(uint8_t));
-    memset (&light_message.end_lon, i + 1, sizeof(uint8_t));
-    memset (&light_message.start_timestamp, i + 1, sizeof(uint8_t));
-    memset (&light_message.end_timestamp, i + 1, sizeof(uint8_t));
-    memset (&light_message.max_reading_clear, i + 1, sizeof(uint8_t));
-    memset (&light_message.min_reading_clear, i + 1, sizeof(uint8_t));
-    memset (&light_message.avg_clear, i + 1, sizeof(uint8_t));
-    memset (&light_message.avg_f1, i + 1, sizeof(uint8_t));
-    memset (&light_message.avg_f2, i + 1, sizeof(uint8_t));
-    memset (&light_message.avg_f3, i + 1, sizeof(uint8_t));
-    memset (&light_message.avg_f4, i + 1, sizeof(uint8_t));
-    memset (&light_message.avg_f5, i + 1, sizeof(uint8_t));
-    memset (&light_message.avg_f6, i + 1, sizeof(uint8_t));
-    memset (&light_message.avg_f7, i + 1, sizeof(uint8_t));
-    memset (&light_message.avg_f8, i + 1, sizeof(uint8_t));
-    memset (&light_message.avg_dark, i + 1, sizeof(uint8_t));
-    memset (&light_message.avg_nir, i + 1, sizeof(uint8_t));
-
-    persistent_ram_save_message (LIGHT_TELEMETRY, (uint8_t*) &light_message);
+  for (int i = 0; i < 10 * LIGHT_MSGS_PER_SBD; i++) {
+    memset(&light_message.start_lat, i + 1, sizeof(uint8_t));
+    memset(&light_message.start_lon, i + 1, sizeof(uint8_t));
+    memset(&light_message.end_lat, i + 1, sizeof(uint8_t));
+    memset(&light_message.end_lon, i + 1, sizeof(uint8_t));
+    memset(&light_message.start_timestamp, i + 1, sizeof(uint8_t));
+    memset(&light_message.end_timestamp, i + 1, sizeof(uint8_t));
+    memset(&light_message.max_reading_clear, i + 1, sizeof(uint8_t));
+    memset(&light_message.min_reading_clear, i + 1, sizeof(uint8_t));
+    memset(&light_message.avg_clear, i + 1, sizeof(uint8_t));
+    memset(&light_message.avg_f1, i + 1, sizeof(uint8_t));
+    memset(&light_message.avg_f2, i + 1, sizeof(uint8_t));
+    memset(&light_message.avg_f3, i + 1, sizeof(uint8_t));
+    memset(&light_message.avg_f4, i + 1, sizeof(uint8_t));
+    memset(&light_message.avg_f5, i + 1, sizeof(uint8_t));
+    memset(&light_message.avg_f6, i + 1, sizeof(uint8_t));
+    memset(&light_message.avg_f7, i + 1, sizeof(uint8_t));
+    memset(&light_message.avg_f8, i + 1, sizeof(uint8_t));
+    memset(&light_message.avg_dark, i + 1, sizeof(uint8_t));
+    memset(&light_message.avg_nir, i + 1, sizeof(uint8_t));
+    persistent_ram_save_message(LIGHT_TELEMETRY, (uint8_t *)&light_message);
   }
 
-  watchdog_check_in (IRIDIUM_THREAD);
+  watchdog_check_in(IRIDIUM_THREAD);
 
-  while ( 1 )
-  {
-    if ( !current_message_sent )
-    {
+  while (1) {
+    if (!current_message_sent) {
       LOG("Attempting transmission of NEDWaves telemetry...");
-      ret = iridium->transmit_message (&(msg_buffer[0]), sizeof(sbd_message_type_52));
-      if ( ret == uSWIFT_SUCCESS )
-      {
+      ret = iridium->transmit_message(&(msg_buffer[0]),
+                                      sizeof(sbd_message_type_52));
+      if (ret == uSWIFT_SUCCESS) {
         current_message_sent = true;
-      }
-      else if ( ret == uSWIFT_TIMEOUT )
-      {
+      } else if (ret == uSWIFT_TIMEOUT) {
         break;
       }
 
       continue;
     }
 
-    next_message_type = get_next_telemetry_message (&msg_ptr, &configuration);
-    if ( next_message_type == NO_MESSAGE )
-    {
+    next_message_type = get_next_telemetry_message(&msg_ptr, &configuration);
+    if (next_message_type == NO_MESSAGE) {
       LOG("No messages messages left in cache.");
       break;
     }
 
-    next_message_size = (next_message_type == WAVES_TELEMETRY) ?
-        sizeof(sbd_message_type_52) :
-                        (next_message_type == TURBIDITY_TELEMETRY) ?
-                            sizeof(sbd_message_type_53) :
-                        (next_message_type == LIGHT_TELEMETRY) ?
-                            sizeof(sbd_message_type_54) : 0;
+    next_message_size =
+        (next_message_type == WAVES_TELEMETRY) ? sizeof(sbd_message_type_52)
+        : (next_message_type == TURBIDITY_TELEMETRY)
+            ? sizeof(sbd_message_type_53)
+        : (next_message_type == LIGHT_TELEMETRY) ? sizeof(sbd_message_type_54)
+                                                 : 0;
 
-    if ( next_message_size > 0 )
-    {
-      log_str = (next_message_type == WAVES_TELEMETRY) ?
-          "NEDWaves" :
-                (next_message_type == TURBIDITY_TELEMETRY) ?
-                    "OBS" :
-                (next_message_type == LIGHT_TELEMETRY) ?
-                    "Light" : "Unknown";
+    if (next_message_size > 0) {
+      log_str = (next_message_type == WAVES_TELEMETRY)       ? "NEDWaves"
+                : (next_message_type == TURBIDITY_TELEMETRY) ? "OBS"
+                : (next_message_type == LIGHT_TELEMETRY)     ? "Light"
+                                                             : "Unknown";
       LOG("Attempting transmission of %s telemetry...", log_str);
 
-      if ( iridium->transmit_message (msg_ptr, next_message_size) == uSWIFT_SUCCESS )
-      {
-        persistent_ram_delete_message_element (next_message_type, msg_ptr);
+      if (iridium->transmit_message(msg_ptr, next_message_size) ==
+          uSWIFT_SUCCESS) {
+        persistent_ram_delete_message_element(next_message_type, msg_ptr);
       }
     }
   }
@@ -186,51 +172,40 @@ bool test_iridium_queueing ( void *iridium_ptr )
 
 uint32_t num_gnss_configs_passed = 0;
 uint32_t num_gnss_configs_failed = 0;
-bool test_gnss_config ( void *gnss )
-{
-  GNSS *gnss_ptr = (GNSS*) gnss;
+bool test_gnss_config(void *gnss) {
+  GNSS *gnss_ptr = (GNSS *)gnss;
 
-  for ( int i = 0; i < 100; i++ )
-  {
-    if ( !gnss_apply_config (gnss_ptr) )
-    {
+  for (int i = 0; i < 100; i++) {
+    if (!gnss_apply_config(gnss_ptr)) {
       num_gnss_configs_failed++;
-    }
-    else
-    {
+    } else {
       num_gnss_configs_passed++;
     }
   }
   return true;
 }
 
-bool gnss_test_control_supplement ( void *control )
-{
-  Control *controller_self = (Control*) control;
-  tx_thread_sleep (TX_TIMER_TICKS_PER_SECOND * 10);
+bool gnss_test_control_supplement(void *control) {
+  Control *controller_self = (Control *)control;
+  tx_thread_sleep(TX_TIMER_TICKS_PER_SECOND * 10);
 
-  (void) tx_thread_resume (controller_self->thread_handles->gnss_thread);
-  (void) tx_thread_resume (controller_self->thread_handles->waves_thread);
-//  (void) tx_thread_resume (controller_self->thread_handles->iridium_thread);
-  while ( 1 )
-  {
-    tx_thread_sleep (TX_TIMER_TICKS_PER_SECOND * 1);
+  (void)tx_thread_resume(controller_self->thread_handles->gnss_thread);
+  (void)tx_thread_resume(controller_self->thread_handles->waves_thread);
+  //  (void) tx_thread_resume (controller_self->thread_handles->iridium_thread);
+  while (1) {
+    tx_thread_sleep(TX_TIMER_TICKS_PER_SECOND * 1);
   }
-
 }
 
-bool test_ct_file_writing ( void *ct )
-{
-  CT *dut = (CT*) ct;
+bool test_ct_file_writing(void *ct) {
+  CT *dut = (CT *)ct;
 
-  for ( int i = 0; i < TOTAL_CT_SAMPLES; i++, dut->total_samples++ )
-  {
+  for (int i = 0; i < TOTAL_CT_SAMPLES; i++, dut->total_samples++) {
     dut->samples[i].temp = i * 2.0f;
     dut->samples[i].salinity = i * 5.0f;
   }
 
-  tx_thread_sleep (TX_TIMER_TICKS_PER_SECOND * 5);
+  tx_thread_sleep(TX_TIMER_TICKS_PER_SECOND * 5);
 
-  return (file_system_server_save_ct_raw (dut) == uSWIFT_SUCCESS);
+  return (file_system_server_save_ct_raw(dut) == uSWIFT_SUCCESS);
 }
-

--- a/STM32U5A5ZJTXQ_FLASH.ld
+++ b/STM32U5A5ZJTXQ_FLASH.ld
@@ -38,8 +38,8 @@ ENTRY(Reset_Handler)
 /* Highest address of the user mode stack */
 _estack = ORIGIN(RAM) + LENGTH(RAM); /* end of "RAM" Ram type memory */
 
-_Min_Heap_Size = 0x200; /* required amount of heap */
-_Min_Stack_Size = 0x400; /* required amount of stack */
+_Min_Heap_Size = 0x400; /* required amount of heap */
+_Min_Stack_Size = 0x800; /* required amount of stack */
 
 /* Memories definition */
 MEMORY

--- a/STM32U5A5ZJTXQ_RAM.ld
+++ b/STM32U5A5ZJTXQ_RAM.ld
@@ -37,8 +37,8 @@ ENTRY(Reset_Handler)
 /* Highest address of the user mode stack */
 _estack = ORIGIN(RAM) + LENGTH(RAM); /* end of "RAM" Ram type memory */
 
-_Min_Heap_Size = 0x200; /* required amount of heap */
-_Min_Stack_Size = 0x400; /* required amount of stack */
+_Min_Heap_Size = 0x400; /* required amount of heap */
+_Min_Stack_Size = 0x800; /* required amount of stack */
 
 /* Memories definition */
 MEMORY

--- a/microSWIFT.ld
+++ b/microSWIFT.ld
@@ -38,8 +38,8 @@ ENTRY(Reset_Handler)
 /* Highest address of the user mode stack */
 _estack = ORIGIN(RAM2) + LENGTH(RAM2); /* end of "RAM" Ram type memory */
 
-_Min_Heap_Size = 0x200; /* required amount of heap */
-_Min_Stack_Size = 0x400; /* required amount of stack */
+_Min_Heap_Size = 0x400; /* required amount of heap */
+_Min_Stack_Size = 0x800; /* required amount of stack */
 
 /* Memories definition */
 MEMORY


### PR DESCRIPTION
Adds support for continuous mode in accelerometer, controlled by a configuration flag.

This requires:
* V1.1 accelerometer firmware
* An accelerometer board that has been modified to be continuously powered from the backplane
* V1.5 programmer
